### PR TITLE
Fix for fatal error

### DIFF
--- a/src/Ddeboer/DataImport/Reader/ReaderInterface.php
+++ b/src/Ddeboer/DataImport/Reader/ReaderInterface.php
@@ -15,11 +15,4 @@ interface ReaderInterface extends \Iterator, \Countable
      * @return array
      */
     function getFields();
-
-    /**
-     * Get the total number of data items
-     *
-     * @return int
-     */
-    function count();
 }


### PR DESCRIPTION
Fix for "Can't inherit abstract function Countable::count() (previously declared abstract in Ddeboer\DataImport\Reader\ReaderInterface)"
