### PR TITLE
Add StringToObjectConverter

### DIFF
--- a/src/Ddeboer/DataImport/ValueConverter/StringToObjectConverter.php
+++ b/src/Ddeboer/DataImport/ValueConverter/StringToObjectConverter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Ddeboer\DataImport\ValueConverter;
+
+use Ddeboer\DataImport\ValueConverter\ValueConverterInterface;
+use Doctrine\Common\Persistence\ObjectRepository;
+
+/**
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ */
+class StringToObjectConverter implements ValueConverterInterface
+{
+    /**
+     * @var ObjectRepository
+     */
+    private $repository;
+
+    /**
+     * @var string
+     */
+    private $property;
+
+    public function __construct(ObjectRepository $repository, $property)
+    {
+        $this->repository = $repository;
+        $this->property = $property;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function convert($input)
+    {
+        $method = 'findOneBy'.ucfirst($this->property);
+        return $this->repository->$method($input);
+    }
+}

--- a/tests/Ddeboer/DataImport/Tests/ValueConverter/StringToObjectConverterTest.php
+++ b/tests/Ddeboer/DataImport/Tests/ValueConverter/StringToObjectConverterTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Ddeboer\DataImport\ValueConverter;
+
+use Ddeboer\DataImport\ValueConverter\StringToObjectConverter;
+
+/**
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ */
+class StringToObjectConverterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConvert()
+    {
+        $repository = $this->getMock(
+            'Doctrine\\Common\\Persistence\\ObjectRepository',
+            array('find', 'findAll', 'findBy', 'findOneBy', 'getClassName', 'findOneByName')
+        );
+
+        $converter = new StringToObjectConverter($repository, 'name');
+
+        $class = new \stdClass();
+
+        $repository->expects($this->once())
+            ->method('findOneByName')
+            ->with('bar')
+            ->will($this->returnValue($class));
+
+        $this->assertEquals($class, $converter->convert('bar'));
+    }
+}


### PR DESCRIPTION
This PR added the abilitly to convert a string to a object.

Use case:
You have a CSV file and want to import the CSV file into your database. Now you can map this property, with this converter.

``` php
$workflow = new Workflow(new CSVReader($file));
$workflow->addValueConverter('name', new StringToObjectConveter($repository, 
'username'));
$workflow->addWriter(new DoctrineWriter($objectManager));
$workflow->process();
```
