### PR TITLE
CsvReader fixing in reading if last line has error

### DIFF
--- a/src/Ddeboer/DataImport/Reader/CsvReader.php
+++ b/src/Ddeboer/DataImport/Reader/CsvReader.php
@@ -108,10 +108,14 @@ class CsvReader implements ReaderInterface, \SeekableIterator
             } else {
                 // They are not equal, so log the row as error and skip it.
                 if ($this->valid()) {
-                    $this->errors[$this->key()] = $line;
+                    $this->errors[$this->key()] = $line;                    
                     $this->next();
-
-                    return $this->current();
+                    $current = $this->current();
+                    if (isset($current)) {
+                        return $current;
+                    }
+                    $this->seek($this->key());
+                    return $line;     
                 }
             }
         } else {


### PR DESCRIPTION
When strict mode is set to TRUE and the last line of the file has more/less elements than the column headers, iterator is broken and the key returned is not which is supposed to be. 