### PR TITLE
Move item mapping out of workflow and into new converter

### DIFF
--- a/src/Ddeboer/DataImport/ItemConverter/MappingItemConverter.php
+++ b/src/Ddeboer/DataImport/ItemConverter/MappingItemConverter.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Ddeboer\DataImport\ItemConverter;
+
+class MappingItemConverter implements ItemConverterInterface
+{
+    /**
+     * @var array
+     */
+    protected $mappings = array();
+
+    /**
+     * Constructor
+     *
+     * @param array $mappings Mappings (optional)
+     */
+    public function __construct(array $mappings = array())
+    {
+        $this->setMappings($mappings);
+    }
+
+    /**
+     * Add a mapping
+     *
+     * @param string       $from Field to map from
+     * @param string|array $to   Field name or array to map to
+     *
+     * @return $this
+     */
+    public function addMapping($from, $to)
+    {
+        $this->mappings[$from] = $to;
+
+        return $this;
+    }
+
+    /**
+     * Set mappings
+     *
+     * @param array $mappings
+     *
+     * @return $this
+     */
+    public function setMappings(array $mappings)
+    {
+        $this->mappings = array();
+
+        foreach ($mappings as $from => $to) {
+            $this->addMapping($from, $to);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convert($input)
+    {
+        foreach ($this->mappings as $from => $to) {
+            $input = $this->applyMapping($input, $from, $to);
+        }
+
+        return $input;
+    }
+
+    /**
+     * Applies a mapping to an item
+     *
+     * @param array  $item
+     * @param string $from
+     * @param string $to
+     *
+     * @return array
+     */
+    protected function applyMapping(array $item, $from, $to)
+    {
+        // skip fields that dont exist
+        if (!isset($item[$from])) {
+            return;
+        }
+
+        // skip equal fields
+        if ($from == $to) {
+            return $item;
+        }
+
+        // standard renaming
+        if (!is_array($to)) {
+            $item[$to] = $item[$from];
+            unset($item[$from]);
+
+            return $item;
+        }
+
+        // recursive renaming of an array
+        foreach ($to as $nestedFrom => $nestedTo) {
+            $item[$from] = $this->applyMapping($item[$from], $nestedFrom, $nestedTo);
+        }
+
+        return $item;
+    }
+}

--- a/tests/Ddeboer/DataImport/Tests/ItemConverter/MappingItemConverterTest.php
+++ b/tests/Ddeboer/DataImport/Tests/ItemConverter/MappingItemConverterTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ddeboer\DataImport\Tests\ItemConverter;
+
+use Ddeboer\DataImport\ItemConverter\MappingItemConverter;
+
+class MappingItemConverterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConvert()
+    {
+        $input = array(
+            'foo' => 'bar',
+            'baz' => array(
+                'another' => 'thing'
+            )
+        );
+
+        $converter = new MappingItemConverter();
+        $converter->addMapping('foo', 'bazinga')
+            ->addMapping('baz', array('another' => 'somethingelse'));
+
+        $output = $converter->convert($input);
+
+        $expected = array(
+            'bazinga' => 'bar',
+            'baz' => array(
+                'somethingelse' => 'thing'
+            )
+        );
+        $this->assertEquals($expected, $output);
+    }
+}

--- a/tests/Ddeboer/DataImport/Tests/WorkflowTest.php
+++ b/tests/Ddeboer/DataImport/Tests/WorkflowTest.php
@@ -14,7 +14,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 {
     public function testAddCallbackFilter()
     {
-        $this->getWorkflow()->addFilter(new CallbackFilter(function($input) {
+        $this->getWorkflow()->addFilter(new CallbackFilter(function () {
             return true;
         }));
     }
@@ -81,7 +81,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('bar', $ouputTestData[0]);
     }
 
-    public function testGlobalMappingAnItem()
+    public function testMapping()
     {
         $originalData = array(array(
             'foo' => 'bar',
@@ -95,48 +95,14 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
         $workflow = new Workflow($reader);
 
-        $mapping = array(
-            'foo' => 'bazinga',
-            'baz' => array('another' => 'somethingelse')
-        );
-
-        $workflow->setGlobalMapping($mapping)
+        $workflow->addMapping('foo', 'bazinga')
+            ->addMapping('baz', array('another' => 'somethingelse'))
             ->addWriter($writer)
             ->process()
         ;
 
         $this->assertArrayHasKey('bazinga', $ouputTestData[0]);
         $this->assertArrayHasKey('somethingelse', $ouputTestData[0]['baz']);
-    }
-
-    public function testGlobalMappingAnItemInCombinationWithMappingAnItem()
-    {
-        $originalData = array(array(
-            'foo' => 'bar',
-            'baz' => array('another' => 'thing')
-        ));
-
-        $ouputTestData = array();
-
-        $writer = new ArrayWriter($ouputTestData);
-        $reader = new ArrayReader($originalData);
-
-        $workflow = new Workflow($reader);
-
-        $mapping = array(
-            'foo' => 'bazinga',
-            'bazoo' => array('another' => 'somethingelse')
-        );
-
-        $workflow->setGlobalMapping($mapping)
-            ->addMapping('baz', 'bazoo')
-            ->addWriter($writer)
-            ->process()
-        ;
-
-        $this->assertArrayHasKey('bazinga', $ouputTestData[0]);
-        $this->assertArrayHasKey('bazoo', $ouputTestData[0]);
-        $this->assertArrayHasKey('somethingelse', $ouputTestData[0]['bazoo']);
     }
 
     public function testWorkflowWithObjects()


### PR DESCRIPTION
This PR moves all mapping functionality out of the `Workflow` class, and into new `MappingItemConverter`. Also, there's no longer and difference between normal and 'global' mappings: I've removed the latter.

To be somewhat backwards-compatible, the `Workflow::addMapping` method still exists. It will now create a `MappingItemConverter` and use that, instead.
