### PR TITLE
Add the ability to skip current processed item on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Broadly speaking, you can use this library in two ways:
 Each data import revolves around the workflow and takes place along the following lines:
 
 1. Construct a [reader](#readers).
-2. Construct a workflow and pass the reader to it. Add at least one
-   [writer](#writers) to the workflow.
+2. Construct a workflow and pass the reader to it, optionaly pass a logger as second argument.
+   Add at least one [writer](#writers) to the workflow.
 3. Optionally, add [filters](#filters), item converters and
    [value converters](#value-converters) to the workflow.
 4. Process the workflow. This will read the data from the reader, filter and
@@ -103,6 +103,9 @@ Each data import revolves around the workflow and takes place along the followin
 
 In other words, the workflow acts as a [mediator](#http://en.wikipedia.org/wiki/Mediator_pattern)
 between a reader and one or more writers, filters and converters.
+
+Optionally you can skip items on failure like this `$workflow->setSkipItemOnFailure(true)`.
+Errors will be logged if you have passed a logger to the workflow constructor.
 
 Schematically:
 
@@ -113,11 +116,12 @@ use Ddeboer\DataImport\Writer;
 use Ddeboer\DataImport\Filter;
 
 $reader = new Reader\...;
-$workflow = new Workflow($reader);
+$workflow = new Workflow($reader, $logger);
 $workflow
     ->addWriter(new Writer\...())
     ->addWriter(new Writer\...())
     ->addFilter(new Filter\CallbackFilter(...))
+    ->setSkipItemOnFailure(true)
     ->process()
 ;
 ```

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "source": "https://github.com/ddeboer/data-import"
     },
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "psr/log": "1.0.0"
     },
     "require-dev": {
         "ext-iconv": "*",

--- a/src/Ddeboer/DataImport/Exception/DuplicateHeadersException.php
+++ b/src/Ddeboer/DataImport/Exception/DuplicateHeadersException.php
@@ -2,7 +2,7 @@
 
 namespace Ddeboer\DataImport\Exception;
 
-class DuplicateHeadersException extends ReaderException
+class DuplicateHeadersException extends ReaderException implements ExceptionInterface
 {
     public function __construct(array $duplicates)
     {

--- a/src/Ddeboer/DataImport/Exception/ExceptionInterface.php
+++ b/src/Ddeboer/DataImport/Exception/ExceptionInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Ddeboer\DataImport\Exception;
+
+/**
+ * Base exception
+ *
+ */
+interface ExceptionInterface
+{
+}
+

--- a/src/Ddeboer/DataImport/Exception/ReaderException.php
+++ b/src/Ddeboer/DataImport/Exception/ReaderException.php
@@ -2,6 +2,6 @@
 
 namespace Ddeboer\DataImport\Exception;
 
-class ReaderException extends \UnexpectedValueException
+class ReaderException extends UnexpectedValueException implements ExceptionInterface
 {
 }

--- a/src/Ddeboer/DataImport/Exception/SourceNotFoundException.php
+++ b/src/Ddeboer/DataImport/Exception/SourceNotFoundException.php
@@ -5,6 +5,6 @@ namespace Ddeboer\DataImport\Exception;
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  */
-class SourceNotFoundException extends \Exception
+class SourceNotFoundException extends \Exception implements ExceptionInterface
 {
 }

--- a/src/Ddeboer/DataImport/Exception/UnexpectedTypeException.php
+++ b/src/Ddeboer/DataImport/Exception/UnexpectedTypeException.php
@@ -11,7 +11,7 @@
 
 namespace Ddeboer\DataImport\Exception;
 
-class UnexpectedTypeException extends \UnexpectedValueException
+class UnexpectedTypeException extends \UnexpectedValueException implements ExceptionInterface
 {
     public function __construct($value, $expectedType)
     {

--- a/src/Ddeboer/DataImport/Exception/UnexpectedValueException.php
+++ b/src/Ddeboer/DataImport/Exception/UnexpectedValueException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Ddeboer\DataImport\Exception;
+
+class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
+{
+}
+

--- a/src/Ddeboer/DataImport/Exception/ValidationException.php
+++ b/src/Ddeboer/DataImport/Exception/ValidationException.php
@@ -4,7 +4,7 @@ namespace Ddeboer\DataImport\Exception;
 
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
-class ValidationException extends \Exception
+class ValidationException extends \Exception implements ExceptionInterface
 {
     private $violations;
 


### PR DESCRIPTION
Add the ability to skip current processed item on failure, if `skipItemOnFailure`attribute is set to `true` `\Ddeboer\DataImport\Exception` will be catched and logger be called with exception message.

The logger of `Psr\Log\LoggerInterface` interface can be passed optionally to the workflow constructor.

What do you think about this proposal ?

I you agree i can write some tests and docs.
