### PR TITLE
Use Symfony 2.5 ProgressBar Helper + allow option to set verbosity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpoffice/phpexcel": "*",
         "doctrine/dbal": "*",
         "doctrine/orm": "*",
-        "symfony/console": ">=2.2,<2.5",
+        "symfony/console": "~2.5.0",
         "symfony/validator": "~2.3.0"
     },
     "suggest": {

--- a/src/Ddeboer/DataImport/Writer/ConsoleProgressWriter.php
+++ b/src/Ddeboer/DataImport/Writer/ConsoleProgressWriter.php
@@ -4,7 +4,7 @@ namespace Ddeboer\DataImport\Writer;
 
 use Ddeboer\DataImport\Reader\ReaderInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Helper\ProgressHelper;
+use Symfony\Component\Console\Helper\ProgressBar;
 
 /**
  * Writes output to the Symfony2 console
@@ -16,16 +16,18 @@ class ConsoleProgressWriter extends AbstractWriter
     protected $progress;
     protected $workflow;
 
-    public function __construct(OutputInterface $output, ReaderInterface $reader)
+    public function __construct(OutputInterface $output, ReaderInterface $reader, $verbosity = 'debug')
     {
-        $this->output = $output;
-        $this->progress = new ProgressHelper();
-        $this->reader = $reader;
+        $this->output       = $output;
+        $this->reader       = $reader;
+        $this->verbosity    = $verbosity;
     }
 
     public function prepare()
     {
-        $this->progress->start($this->output, $this->reader->count());
+        $this->progress = new ProgressBar($this->output, $this->reader->count());
+        $this->progress->setFormat($this->verbosity);
+        $this->progress->start();
     }
 
     public function writeItem(array $item)
@@ -36,5 +38,10 @@ class ConsoleProgressWriter extends AbstractWriter
     public function finish()
     {
         $this->progress->finish();
+    }
+
+    public function getVerbosity()
+    {
+        return $this->verbosity;
     }
 }

--- a/tests/Ddeboer/DataImport/Tests/Writer/ConsoleProgressWriterTest.php
+++ b/tests/Ddeboer/DataImport/Tests/Writer/ConsoleProgressWriterTest.php
@@ -21,8 +21,18 @@ class ConsoleProgressWriterTest extends \PHPUnit_Framework_TestCase
         );
         $reader = new ArrayReader($data);
 
-        $output = $this->getMockBuilder('\Symfony\Component\Console\Output\ConsoleOutput')
+        $output = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
             ->getMock();
+
+        $outputFormatter = $this->getMock('Symfony\Component\Console\Formatter\OutputFormatterInterface');
+        $output->expects($this->once())
+            ->method('isDecorated')
+            ->will($this->returnValue(true));
+
+        $output->expects($this->atLeastOnce())
+            ->method('getFormatter')
+            ->will($this->returnValue($outputFormatter));
+
         $output->expects($this->atLeastOnce())
             ->method('write');
         $writer = new ConsoleProgressWriter($output, $reader);
@@ -30,5 +40,7 @@ class ConsoleProgressWriterTest extends \PHPUnit_Framework_TestCase
         $workflow = new Workflow($reader);
         $workflow->addWriter($writer)
             ->process();
+
+        $this->assertEquals('debug', $writer->getVerbosity());
     }
 }


### PR DESCRIPTION
Hey, I've updated the ConsoleProgressWriter to use a new Symfony 2.5 ProgressBar Helper. It allows for ETA output which is pretty nice and something we needed for a project. You might want to wait for the 2.5 Console Component to become stable before merging (If you want it!) 
