### PR TITLE
FIX: MappingItemConverter skips null fields

### DIFF
--- a/src/Ddeboer/DataImport/ItemConverter/MappingItemConverter.php
+++ b/src/Ddeboer/DataImport/ItemConverter/MappingItemConverter.php
@@ -76,7 +76,7 @@ class MappingItemConverter implements ItemConverterInterface
     protected function applyMapping(array $item, $from, $to)
     {
         // skip fields that dont exist
-        if (!isset($item[$from])) {
+        if (!isset($item[$from]) && !array_key_exists($from, $item)) {
             return $item;
         }
 


### PR DESCRIPTION
This fixes issue #84, in the same way as 0aeb02d.

Now fields with null values are not skipped anymore.
