### PR TITLE
Fixed php-error "undefined offset" when adding an item-converter and multiple mappings

### DIFF
--- a/src/Ddeboer/DataImport/Workflow.php
+++ b/src/Ddeboer/DataImport/Workflow.php
@@ -359,7 +359,8 @@ class Workflow
 
         if (count($converters) > 0) {
             // Return first mapping item converter that we encounter
-            $converter = $converters[0];
+            reset($converters);
+            $converter = current($converters);
         } else {
             // Create default converter
             $converter = new MappingItemConverter();

--- a/tests/Ddeboer/DataImport/Tests/WorkflowTest.php
+++ b/tests/Ddeboer/DataImport/Tests/WorkflowTest.php
@@ -324,6 +324,34 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(null, $result->getName());
     }
 
+    public function testMultipleMappingsForAnItemAfterAnotherItemConverterwasAdded()
+    {
+        $originalData = array(array('foo' => 'bar', 'baz' => 'value'));
+
+        $ouputTestData = array();
+
+        $writer = new ArrayWriter($ouputTestData);
+        $reader = new ArrayReader($originalData);
+
+        $workflow = new Workflow($reader);
+
+        // add a dummy item converter
+        $workflow->addItemConverter(new CallbackItemConverter(function($item) {
+                return $item;
+            }));
+
+        // add multiple mappings
+        $workflow
+            ->addMapping('foo', 'bar')
+            ->addMapping('baz', 'bazzoo')
+            ->addWriter($writer)
+            ->process()
+        ;
+
+        $this->assertArrayHasKey('bar', $ouputTestData[0]);
+        $this->assertArrayHasKey('bazzoo', $ouputTestData[0]);
+    }
+
     public function testWorkflowResultWithExceptionThrowFromWriter()
     {
         $workflow   = $this->getWorkflow();


### PR DESCRIPTION
A php error was thrown:

```
Undefined offset: 0
```

when adding a CallbackItemConverter and after that adding multiple mappings:

``` php
$workflow->addItemConverter(new CallbackItemConverter(function($item) {
    return $item;
}));

$workflow
    ->addMapping('foo', 'bar') // works
    ->addMapping('baz', 'bazzoo') // breaks
;
```

This is caused by the **getMappingItemConverter** method which accesses $converters with an index 0 instead of current

``` php
$converters = \array_filter(
    $this->itemConverters,
    function ($converter) {
        return $converter instanceof MappingItemConverter;
    }
);

if (count($converters) > 0) {
    // this breaks because the MappingItemConverter is located at "1"
    // because array_filter preservers the keys
    $converter = $converters[0];
}
```
