### PR TITLE
Add UTF-8 encoding to CsvWriter

### DIFF
--- a/src/Ddeboer/DataImport/Writer/CsvWriter.php
+++ b/src/Ddeboer/DataImport/Writer/CsvWriter.php
@@ -9,6 +9,7 @@ class CsvWriter extends AbstractStreamWriter
 {
     private $delimiter = ';';
     private $enclosure = '"';
+    private $utf8Encoding = false;
 
     /**
      * Constructor
@@ -16,13 +17,27 @@ class CsvWriter extends AbstractStreamWriter
      * @param string   $delimiter The delimiter
      * @param string   $enclosure The enclosure
      * @param resource $stream
+     * @param bool     $utf8Encoding
      */
-    public function __construct($delimiter = ';', $enclosure = '"', $stream = null)
+    public function __construct($delimiter = ';', $enclosure = '"', $stream = null, $utf8Encoding = false)
     {
         parent::__construct($stream);
 
         $this->delimiter = $delimiter;
         $this->enclosure = $enclosure;
+        $this->utf8Encoding = $utf8Encoding;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function prepare()
+    {
+        if ($this->utf8Encoding) {
+            fprintf($this->getStream(), chr(0xEF) . chr(0xBB) . chr(0xBF));
+        }
+
+        return $this;
     }
 
     /**

--- a/tests/Ddeboer/DataImport/Tests/Writer/CsvWriterTest.php
+++ b/tests/Ddeboer/DataImport/Tests/Writer/CsvWriterTest.php
@@ -10,6 +10,7 @@ class CsvWriterTest extends StreamWriterTest
     {
         $writer = new CsvWriter(';', '"', $this->getStream());
 
+        $writer->prepare();
         $writer->writeItem(array('first', 'last'));
 
         $writer
@@ -23,6 +24,21 @@ class CsvWriterTest extends StreamWriterTest
             ));
         $this->assertContentsEquals(
             "first;last\nJames;Bond\n;\"Dr. No\"\n",
+            $writer
+        );
+
+        $writer->finish();
+    }
+
+    public function testWriteUtf8Item()
+    {
+        $writer = new CsvWriter(';', '"', $this->getStream(), true);
+
+        $writer->prepare();
+        $writer->writeItem(array('Précédent', 'Suivant'));
+
+        $this->assertContentsEquals(
+            chr(0xEF) . chr(0xBB) . chr(0xBF) . "Précédent;Suivant\n",
             $writer
         );
 


### PR DESCRIPTION
When creating a csv file, UTF-8 encoded strings aren't supported in Excel without "chr(0xEF) . chr(0xBB) . chr(0xBF)" at the beginning of the file.

Example with french words : 

    $writer = new CsvWriter(';', '"', null, true);
    $writer->writeItem(array('Précédent', 'Suivant'));
    $writer->finish();

Question : In the CsvWriter constructor, why is the stream in the third position? In ArrayWriter and ExcelWriter the output is the first parameter.