### PR TITLE
Match Exceptions to the rows they came from

### DIFF
--- a/src/Ddeboer/DataImport/Workflow.php
+++ b/src/Ddeboer/DataImport/Workflow.php
@@ -240,7 +240,7 @@ class Workflow
         }
 
         // Read all items
-        foreach ($this->reader as $item) {
+        foreach ($this->reader as $rowIndex => $item) {
             try {
                 // Apply filters before conversion
                 if (!$this->filterItem($item, $this->filters)) {
@@ -263,7 +263,7 @@ class Workflow
 
             } catch(ExceptionInterface $e) {
                 if ($this->skipItemOnFailure) {
-                    $exceptions[] = $e;
+                    $exceptions[$rowIndex] = $e;
                     $this->logger->error($e->getMessage());
                 } else {
                     throw $e;


### PR DESCRIPTION
When importing it may be nice to be able to tell the user that a particular row is where the exception occurred. This allows us to use the loop index to map an exception to a particular row so that programs could provide additional information to the users if desired.
