### PR TITLE
Test that the index field is not empty

### DIFF
--- a/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
+++ b/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
@@ -179,7 +179,7 @@ class DoctrineWriter extends AbstractWriter
         // If the table was not truncated to begin with, find current entities
         // first
         if (false === $this->truncate) {
-            if ($this->index) {
+            if ($this->index && !empty($item[$this->index])) {
                 $entity = $this->entityRepository->findOneBy(
                     array($this->index => $item[$this->index])
                 );


### PR DESCRIPTION
We have a case where it is possible that someone is passing in data that may or may not have been saved to our DB already. In this case these index fields may be empty as such there is no reason to try to retrieve it.
