### PR TITLE
Pass the entityName to the entityManager clear()

### DIFF
--- a/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
+++ b/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
@@ -162,7 +162,7 @@ class DoctrineWriter extends AbstractWriter
     public function finish()
     {
         $this->entityManager->flush();
-        $this->entityManager->clear();
+        $this->entityManager->clear($this->entityName);
         $this->reEnableLogging();
 
         return $this;
@@ -219,7 +219,7 @@ class DoctrineWriter extends AbstractWriter
 
         if (($this->counter % $this->batchSize) == 0) {
             $this->entityManager->flush();
-            $this->entityManager->clear();
+            $this->entityManager->clear($this->entityName);
         }
 
         return $this;


### PR DESCRIPTION
There's no reason to clear the entitymanager of _all_ entities. In our case we have pulled some linked associations for a particular workflow, however once the batchSize is up, suddenly doctrine detects new unmanaged entities and suggests adding a cascade={"persist"}. This will cause duplicate records to be created. We tried listening to the onClear event to reload however that presented other issues.

Since the import process shouldn't really affect other things the user may have done this change fixes that by only clearing entities of this particular class type.
