### PR TITLE
Wrap conversion exceptions in a ValueConversionException

### DIFF
--- a/src/Ddeboer/DataImport/Exception/InvalidArgumentException.php
+++ b/src/Ddeboer/DataImport/Exception/InvalidArgumentException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ddeboer\DataImport\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Ddeboer/DataImport/Exception/ValueConversionException.php
+++ b/src/Ddeboer/DataImport/Exception/ValueConversionException.php
@@ -4,5 +4,8 @@ namespace Ddeboer\DataImport\Exception;
 
 class ValueConversionException extends \UnexpectedValueException implements ExceptionInterface
 {
+    public function __construct($property, $previousException)
+    {
+        parent::__construct(sprintf('Unable to convert value for "%s"', $property),null,$previousException);
+    }
 }
-

--- a/src/Ddeboer/DataImport/Exception/ValueConversionException.php
+++ b/src/Ddeboer/DataImport/Exception/ValueConversionException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Ddeboer\DataImport\Exception;
+
+class ValueConversionException extends \UnexpectedValueException implements ExceptionInterface
+{
+}
+

--- a/src/Ddeboer/DataImport/ValueConverter/ArrayValueConverterMap.php
+++ b/src/Ddeboer/DataImport/ValueConverter/ArrayValueConverterMap.php
@@ -9,7 +9,7 @@ use \Ddeboer\DataImport\Exception\InvalidArgumentException;
  *
  * @author Christoph Rosse <christoph@rosse.at>
  */
-class ArrayValueConverterMap implements \Ddeboer\DataImport\ValueConverter\ValueConverterInterface
+class ArrayValueConverterMap implements ValueConverterInterface
 {
     /**
      * @var array

--- a/src/Ddeboer/DataImport/ValueConverter/ArrayValueConverterMap.php
+++ b/src/Ddeboer/DataImport/ValueConverter/ArrayValueConverterMap.php
@@ -2,12 +2,14 @@
 
 namespace Ddeboer\DataImport\ValueConverter;
 
+use \Ddeboer\DataImport\Exception\InvalidArgumentException;
+
 /**
  * Converts a nested array using a converter-map
  *
  * @author Christoph Rosse <christoph@rosse.at>
  */
-class ArrayValueConverterMap implements ValueConverterInterface
+class ArrayValueConverterMap implements \Ddeboer\DataImport\ValueConverter\ValueConverterInterface
 {
     /**
      * @var array
@@ -30,7 +32,7 @@ class ArrayValueConverterMap implements ValueConverterInterface
     public function convert($input)
     {
         if (!is_array($input)) {
-            throw new \InvalidArgumentException('Input of a ArrayValueConverterMap must be an array');
+            throw new InvalidArgumentException('Input of a ArrayValueConverterMap must be an array');
         }
 
         foreach ($input as $key => $item) {

--- a/src/Ddeboer/DataImport/ValueConverter/DateTimeValueConverter.php
+++ b/src/Ddeboer/DataImport/ValueConverter/DateTimeValueConverter.php
@@ -2,12 +2,14 @@
 
 namespace Ddeboer\DataImport\ValueConverter;
 
+use \Ddeboer\DataImport\Exception\UnexpectedValueException;
+
 /**
  * Convert an date string into another date string
  * Eg. You want to change the format of a string OR
  * If no output specified, return DateTime instance
  */
-class DateTimeValueConverter implements ValueConverterInterface
+class DateTimeValueConverter implements \Ddeboer\DataImport\ValueConverter\ValueConverterInterface
 {
     /**
      * Date time format
@@ -56,7 +58,7 @@ class DateTimeValueConverter implements ValueConverterInterface
         if ($this->inputFormat) {
             $date = \DateTime::createFromFormat($this->inputFormat, $input);
             if (false === $date) {
-                throw new \UnexpectedValueException(
+                throw new UnexpectedValueException(
                     $input . ' is not a valid date/time according to format ' . $this->inputFormat
                 );
             }

--- a/src/Ddeboer/DataImport/ValueConverter/DateTimeValueConverter.php
+++ b/src/Ddeboer/DataImport/ValueConverter/DateTimeValueConverter.php
@@ -3,13 +3,14 @@
 namespace Ddeboer\DataImport\ValueConverter;
 
 use \Ddeboer\DataImport\Exception\UnexpectedValueException;
+use \Ddeboer\DataImport\ValueConverter\ValueConverterInterface;
 
 /**
  * Convert an date string into another date string
  * Eg. You want to change the format of a string OR
  * If no output specified, return DateTime instance
  */
-class DateTimeValueConverter implements \Ddeboer\DataImport\ValueConverter\ValueConverterInterface
+class DateTimeValueConverter implements ValueConverterInterface
 {
     /**
      * Date time format

--- a/src/Ddeboer/DataImport/Workflow.php
+++ b/src/Ddeboer/DataImport/Workflow.php
@@ -7,6 +7,7 @@ use Psr\Log\NullLogger;
 
 use Ddeboer\DataImport\Exception\UnexpectedTypeException;
 use Ddeboer\DataImport\Exception\ExceptionInterface;
+use Ddeboer\DataImport\Exception\ValueConversionException;
 use Ddeboer\DataImport\ItemConverter\MappingItemConverter;
 use Ddeboer\DataImport\Reader\ReaderInterface;
 use Ddeboer\DataImport\Writer\WriterInterface;
@@ -334,7 +335,11 @@ class Workflow
             // as isset() is much faster.
             if (isset($item[$property]) || array_key_exists($property, $item)) {
                 foreach ($converters as $converter) {
-                    $item[$property] = $converter->convert($item[$property]);
+                    try {
+                        $item[$property] = $converter->convert($item[$property]);
+                    } catch (ExceptionInterface $e) {
+                        throw new ValueConversionException("Unable to convert value for '$property'",null,$e);
+                    }
                 }
             }
         }

--- a/src/Ddeboer/DataImport/Workflow.php
+++ b/src/Ddeboer/DataImport/Workflow.php
@@ -338,7 +338,7 @@ class Workflow
                     try {
                         $item[$property] = $converter->convert($item[$property]);
                     } catch (ExceptionInterface $e) {
-                        throw new ValueConversionException("Unable to convert value for '$property'",null,$e);
+                        throw new ValueConversionException($property,$e);
                     }
                 }
             }


### PR DESCRIPTION
To help provide better error reporting to users wrap the
conversion exception into another providing the column or
property that the conversion failed on. This allows for both the
column and row causing the issue.