### PR TITLE
Let the user set custom filters priorities

### DIFF
--- a/src/Ddeboer/DataImport/Filter/CallbackFilter.php
+++ b/src/Ddeboer/DataImport/Filter/CallbackFilter.php
@@ -15,6 +15,11 @@ class CallbackFilter implements FilterInterface
     private $callback;
 
     /**
+     * @var int
+     */
+    private $priority = 0;
+
+    /**
      * Constructor
      *
      * @param callable $callback
@@ -43,6 +48,14 @@ class CallbackFilter implements FilterInterface
      */
     public function getPriority()
     {
-        return 0;
+        return $this->priority;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPriority($priority)
+    {
+        $this->priority = $priority;
     }
 }

--- a/src/Ddeboer/DataImport/Filter/FilterInterface.php
+++ b/src/Ddeboer/DataImport/Filter/FilterInterface.php
@@ -22,4 +22,11 @@ interface FilterInterface
      * @return int
      */
     public function getPriority();
+
+    /**
+     * Set filter priority (higher number means higher priority)
+     *
+     * @param in $priority Filter priority
+     */
+    public function setPriority($priority);
 }

--- a/src/Ddeboer/DataImport/Filter/OffsetFilter.php
+++ b/src/Ddeboer/DataImport/Filter/OffsetFilter.php
@@ -36,6 +36,11 @@ class OffsetFilter implements FilterInterface
     protected $maxLimitHit = false;
 
     /**
+     * @var int
+     */
+    private $priority = 128;
+
+    /**
      * Constructor
      *
      * @param int      $offset 0-based index of the item to start read from
@@ -87,6 +92,14 @@ class OffsetFilter implements FilterInterface
      */
     public function getPriority()
     {
-        return 128;
+        return $this->priority;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPriority($priority)
+    {
+        $this->priority = $priority;
     }
 }

--- a/src/Ddeboer/DataImport/Filter/ValidatorFilter.php
+++ b/src/Ddeboer/DataImport/Filter/ValidatorFilter.php
@@ -19,6 +19,8 @@ class ValidatorFilter implements FilterInterface
 
     private $violations = array();
 
+    private $priority = 256;
+
     public function __construct(ValidatorInterface $validator)
     {
         $this->validator = $validator;
@@ -66,6 +68,14 @@ class ValidatorFilter implements FilterInterface
      */
     public function getPriority()
     {
-        return 256;
+        return $this->priority;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPriority($priority)
+    {
+        $this->priority = $priority;
     }
 }


### PR DESCRIPTION
This PR doesn't change the filters priorities but it allows the user to set custom ones. I needed this feature because I wanted the OffsetFilter to be processed before the ValidatorFilter and I didn't want to break the library's behavior.
