### PR TITLE
Use commas for the CSV Reader

### DIFF
--- a/src/Ddeboer/DataImport/Reader/Factory/CsvReaderFactory.php
+++ b/src/Ddeboer/DataImport/Reader/Factory/CsvReaderFactory.php
@@ -19,7 +19,7 @@ class CsvReaderFactory
     public function __construct(
         $headerRowNumber = null,
         $strict = true,
-        $delimiter = ';',
+        $delimiter = ',',
         $enclosure = '"',
         $escape = '\\'
     ) {


### PR DESCRIPTION
Since CSV means comma separated values it seems only logical that its the default. A similar change was made against the CsvReader awhile back and I just noticed the CsvReaderFactory has the same issue.