### PR TITLE
No writer accepts two arguments to writeItem()

### DIFF
--- a/src/Ddeboer/DataImport/Workflow.php
+++ b/src/Ddeboer/DataImport/Workflow.php
@@ -258,7 +258,7 @@ class Workflow
                 }
 
                 foreach ($this->writers as $writer) {
-                    $writer->writeItem($convertedItem, $item);
+                    $writer->writeItem($convertedItem);
                 }
 
             } catch(ExceptionInterface $e) {


### PR DESCRIPTION
The WriterInterface defines writeItem(array $item). However the Workflow->process() calls $writer->writeItem($convertedItem,$item); $item is never used an no writer seems to use it. It is also not part of the interface.
