### PR TITLE
ValidatorFilter now only validates fields with constraints

### DIFF
--- a/src/Ddeboer/DataImport/Filter/ValidatorFilter.php
+++ b/src/Ddeboer/DataImport/Filter/ValidatorFilter.php
@@ -45,20 +45,26 @@ class ValidatorFilter implements FilterInterface
 
     public function filter(array $item)
     {
-        $constraints = new Constraints\Collection($this->constraints);
-        $list = $this->validator->validateValue($item, $constraints);
+        $isValid = true;
+        foreach ($item as $field => $value) {
+            if (!empty($this->constraints[$field])) {
+                $list = $this->validator->validateValue($value, $this->constraints[$field]);
 
-        if (count($list) > 0) {
-            $this->violations[$this->line] = $list;
+                if (count($list) > 0) {
+                    $this->violations[$this->line] = $list;
 
-            if ($this->throwExceptions) {
-                throw new ValidationException($list, $this->line);
+                    if ($this->throwExceptions) {
+                        throw new ValidationException($list, $this->line);
+                    }
+
+                    $isValid = false;
+                }
             }
         }
 
         $this->line++;
 
-        return 0 === count($list);
+        return $isValid;
     }
 
     /**

--- a/tests/Ddeboer/DataImport/Tests/Filter/ValidationFilterTest.php
+++ b/tests/Ddeboer/DataImport/Tests/Filter/ValidationFilterTest.php
@@ -3,6 +3,7 @@
 namespace Ddeboer\DataImport\Tests\Filter;
 
 use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Constraints as Assert;
 use Ddeboer\DataImport\Filter\ValidatorFilter;
 use Ddeboer\DataImport\Exception\ValidationException;
 
@@ -20,10 +21,6 @@ class ValidationFilterTest extends \PHPUnit_Framework_TestCase
 
         $list = new ConstraintViolationList();
 
-        $this->validator->expects($this->once())
-            ->method('validateValue')
-            ->will($this->returnValue($list));
-
         $this->assertTrue($this->filter->filter($item));
     }
 
@@ -38,6 +35,7 @@ class ValidationFilterTest extends \PHPUnit_Framework_TestCase
             ->method('validateValue')
             ->will($this->returnValue($list));
 
+        $this->filter->add('foo', new Assert\EqualTo('baz'));
         $this->assertFalse($this->filter->filter($item));
 
         $this->assertEquals(array(1 => $list), $this->filter->getViolations());
@@ -55,8 +53,9 @@ class ValidationFilterTest extends \PHPUnit_Framework_TestCase
         $this->validator->expects($this->once())
             ->method('validateValue')
             ->will($this->returnValue($list));
-        
+
         try {
+            $this->filter->add('foo', new Assert\EqualTo('baz'));
             $this->filter->filter($item);
             $this->fail('ValidationException should be thrown');
         } catch (ValidationException $e) {


### PR DESCRIPTION
Enhancing PR #47, this fix forces the validator to only validate fields which have at least one constraint. That means you no longer need to set constraints on all fields