### PR TITLE
Pass errorCount to writer #165

### DIFF
--- a/src/Ddeboer/DataImport/Result.php
+++ b/src/Ddeboer/DataImport/Result.php
@@ -14,7 +14,6 @@ use Ddeboer\DataImport\Exception\ExceptionInterface;
  */
 class Result
 {
-
     /**
      * Identifier given to the import/export
      *

--- a/src/Ddeboer/DataImport/Workflow.php
+++ b/src/Ddeboer/DataImport/Workflow.php
@@ -274,7 +274,7 @@ class Workflow
 
         // Finish writers
         foreach ($this->writers as $writer) {
-            $writer->finish();
+            $writer->finish(count($exceptions));
         }
 
         return new Result($this->name, $startTime, new DateTime, $count, $exceptions);

--- a/src/Ddeboer/DataImport/Writer/AbstractStreamWriter.php
+++ b/src/Ddeboer/DataImport/Writer/AbstractStreamWriter.php
@@ -71,7 +71,7 @@ abstract class AbstractStreamWriter implements WriterInterface
     /**
      * @inheritdoc
      */
-    public function finish()
+    public function finish($errorCount = null)
     {
         if (is_resource($this->stream) && $this->getCloseStreamOnFinish()) {
             fclose($this->stream);

--- a/src/Ddeboer/DataImport/Writer/AbstractWriter.php
+++ b/src/Ddeboer/DataImport/Writer/AbstractWriter.php
@@ -28,9 +28,11 @@ abstract class AbstractWriter implements WriterInterface
      * This template method can be overridden in concrete writer
      * implementations.
      *
+     * @param $errorCount
+     *
      * @return $this
      */
-    public function finish()
+    public function finish($errorCount = null)
     {
         return $this;
     }

--- a/src/Ddeboer/DataImport/Writer/ArrayWriter.php
+++ b/src/Ddeboer/DataImport/Writer/ArrayWriter.php
@@ -7,7 +7,7 @@ namespace Ddeboer\DataImport\Writer;
  *
  * Class ArrayWriter
  */
-class ArrayWriter implements WriterInterface
+class ArrayWriter extends AbstractWriter
 {
     /**
      * @var array
@@ -38,13 +38,5 @@ class ArrayWriter implements WriterInterface
     public function writeItem(array $item)
     {
         $this->data[] = $item;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function finish()
-    {
-
     }
 }

--- a/src/Ddeboer/DataImport/Writer/CallbackWriter.php
+++ b/src/Ddeboer/DataImport/Writer/CallbackWriter.php
@@ -7,7 +7,7 @@ namespace Ddeboer\DataImport\Writer;
  *
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  */
-class CallbackWriter implements WriterInterface
+class CallbackWriter extends AbstractWriter
 {
     /**
      * @var callable
@@ -18,6 +18,7 @@ class CallbackWriter implements WriterInterface
      * Constructor
      *
      * @param callable $callback
+     * @throws \RuntimeException
      */
     public function __construct($callback)
     {
@@ -31,26 +32,10 @@ class CallbackWriter implements WriterInterface
     /**
      * {@inheritDoc}
      */
-    public function prepare()
-    {
-        return $this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function writeItem(array $item)
     {
         call_user_func($this->callback, $item);
 
-        return $this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function finish()
-    {
         return $this;
     }
 }

--- a/src/Ddeboer/DataImport/Writer/ConsoleProgressWriter.php
+++ b/src/Ddeboer/DataImport/Writer/ConsoleProgressWriter.php
@@ -80,9 +80,9 @@ class ConsoleProgressWriter extends AbstractWriter
     }
 
     /**
-     * @return $this
+     * {@inheritdoc}
      */
-    public function finish()
+    public function finish($errorCount = null)
     {
         $this->progress->finish();
 

--- a/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
+++ b/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
@@ -3,6 +3,7 @@
 namespace Ddeboer\DataImport\Writer;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
 /**
@@ -172,9 +173,10 @@ class DoctrineWriter extends AbstractWriter
     /**
      * Re-enable Doctrine logging
      *
+     * @param $errorCount
      * @return DoctrineWriter
      */
-    public function finish()
+    public function finish($errorCount = null)
     {
         $this->entityManager->flush();
         $this->entityManager->clear($this->entityName);

--- a/src/Ddeboer/DataImport/Writer/ExcelWriter.php
+++ b/src/Ddeboer/DataImport/Writer/ExcelWriter.php
@@ -93,7 +93,7 @@ class ExcelWriter extends AbstractWriter
     /**
      * {@inheritdoc}
      */
-    public function finish()
+    public function finish($errorCount = null)
     {
         $writer = \PHPExcel_IOFactory::createWriter($this->excel, $this->type);
         $writer->save($this->filename);

--- a/src/Ddeboer/DataImport/Writer/PdoWriter.php
+++ b/src/Ddeboer/DataImport/Writer/PdoWriter.php
@@ -15,7 +15,7 @@ use \Ddeboer\DataImport\Exception\WriterException;
  *     $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
  *
  */
-class PdoWriter implements WriterInterface
+class PdoWriter extends AbstractWriter
 {
     /**
      * @var \PDO
@@ -48,14 +48,6 @@ class PdoWriter implements WriterInterface
     /**
      * {@inheritDoc}
      */
-    public function prepare()
-    {
-        return $this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function writeItem(array $item)
     {
         try {
@@ -82,14 +74,6 @@ class PdoWriter implements WriterInterface
             throw new WriterException('Write failed ('.$e->getMessage().').', null, $e);
         }
 
-        return $this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function finish()
-    {
         return $this;
     }
 }

--- a/src/Ddeboer/DataImport/Writer/StreamMergeWriter.php
+++ b/src/Ddeboer/DataImport/Writer/StreamMergeWriter.php
@@ -9,9 +9,14 @@ namespace Ddeboer\DataImport\Writer;
  */
 class StreamMergeWriter extends AbstractStreamWriter
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     private $discriminantField = 'discr';
-    /** @var AbstractStreamWriter[] */
+
+    /**
+     * @var AbstractStreamWriter[]
+     */
     private $writers = array();
 
     /**
@@ -23,6 +28,7 @@ class StreamMergeWriter extends AbstractStreamWriter
     public function setDiscriminantField($discriminantField)
     {
         $this->discriminantField = (string) $discriminantField;
+
         return $this;
     }
 

--- a/src/Ddeboer/DataImport/Writer/WriterInterface.php
+++ b/src/Ddeboer/DataImport/Writer/WriterInterface.php
@@ -28,7 +28,9 @@ interface WriterInterface
     /**
      * Wrap up the writer after all items have been written
      *
+     * @param int|null The number of errors occurred during import.
+     *
      * @return $this
      */
-    public function finish();
+    public function finish($errorCount = null);
 }

--- a/tests/Ddeboer/DataImport/Tests/Filter/CallbackFilterTest.php
+++ b/tests/Ddeboer/DataImport/Tests/Filter/CallbackFilterTest.php
@@ -21,7 +21,7 @@ class CallbackFilterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      */
     public function testFilterWithNotCallableArgument()
     {


### PR DESCRIPTION
This issue fixes #165.

The writer is now aware of the error count / success state of the data import. This can be used for example to commit the write operations only if there was no error.
