### PR TITLE
cascade truncation to other entities

### DIFF
--- a/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
+++ b/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
@@ -278,7 +278,7 @@ class DoctrineWriter extends AbstractWriter
     {
         $tableName = $this->entityMetadata->table['name'];
         $connection = $this->entityManager->getConnection();
-        $query = $connection->getDatabasePlatform()->getTruncateTableSQL($tableName);
+        $query = $connection->getDatabasePlatform()->getTruncateTableSQL($tableName, true);
         $connection->executeQuery($query);
     }
 


### PR DESCRIPTION
truncate will fail with postgresql even if there a relationship exists but is empty. This fix makes sure to cascade truncation to other tables.