### PR TITLE
split out the code that updates an entity from writeItem function

### DIFF
--- a/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
+++ b/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
@@ -192,7 +192,25 @@ class DoctrineWriter extends AbstractWriter
         $entity = $this->findOrCreateItem($item);
 
         $this->loadAssociationObjectsToEntity($item, $entity);
+        $this->updateEntity($item, $entity);
 
+        $this->entityManager->persist($entity);
+
+        if (($this->counter % $this->batchSize) == 0) {
+            $this->entityManager->flush();
+            $this->entityManager->clear($this->entityName);
+        }
+
+        return $this;
+    }
+
+    /**
+     * 
+     * @param array $item
+     * @param object $entity
+     */
+    protected function updateEntity(array $item, $entity)
+    {
         $fieldNames = array_merge($this->entityMetadata->getFieldNames(), $this->entityMetadata->getAssociationNames());
         foreach ($fieldNames as $fieldName) {
 
@@ -213,16 +231,7 @@ class DoctrineWriter extends AbstractWriter
                 $setter = 'set' . ucfirst($fieldName);
                 $this->setValue($entity, $value, $setter);
             }
-        }
-
-        $this->entityManager->persist($entity);
-
-        if (($this->counter % $this->batchSize) == 0) {
-            $this->entityManager->flush();
-            $this->entityManager->clear($this->entityName);
-        }
-
-        return $this;
+        }        
     }
 
     /**


### PR DESCRIPTION
Its cleaner to have separation of duties in the writeItem function. Plus I have a couple use cases where I can use the Doctrine Writer code that updates an entity before writing. So this patch simply moves the updating code to its own function.