### PR TITLE
Proper reaction for SIGTERM and SIGINT

### DIFF
--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -53,6 +53,11 @@ class Workflow implements WorkflowInterface
     private $writers = [];
 
     /**
+     * @var boolean For internal use
+     */
+    protected $shouldStop = false;
+    
+    /**
      * Construct a workflow
      *
      * @param ReaderInterface $reader
@@ -116,8 +121,16 @@ class Workflow implements WorkflowInterface
             $writer->prepare();
         }
 
+        $this->shouldStop = false;
+        pcntl_signal(SIGTERM, array($this, 'stop'));
+        pcntl_signal(SIGINT, array($this, 'stop'));
+
         // Read all items
         foreach ($this->reader as $index => $item) {
+
+            pcntl_signal_dispatch();
+            if ( $this->shouldStop ) break;
+
             try {
                 foreach (clone $this->steps as $step) {
                     if (false === $step->process($item)) {
@@ -149,6 +162,14 @@ class Workflow implements WorkflowInterface
         }
 
         return new Result($this->name, $startTime, new \DateTime, $count, $exceptions);
+    }
+
+    /**
+     * Stops processing and force return Result from process() function
+     */
+    public function stop()
+    {
+        $this->shouldStop = true;
     }
 
     /**

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -56,7 +56,7 @@ class Workflow implements WorkflowInterface
      * @var boolean For internal use
      */
     protected $shouldStop = false;
-    
+
     /**
      * Construct a workflow
      *
@@ -122,13 +122,17 @@ class Workflow implements WorkflowInterface
         }
 
         $this->shouldStop = false;
-        pcntl_signal(SIGTERM, array($this, 'stop'));
-        pcntl_signal(SIGINT, array($this, 'stop'));
+        if (is_callable('pcntl_signal')) {
+            pcntl_signal(SIGTERM, array($this, 'stop'));
+            pcntl_signal(SIGINT, array($this, 'stop'));
+        }
 
         // Read all items
         foreach ($this->reader as $index => $item) {
 
-            pcntl_signal_dispatch();
+            if (is_callable('pcntl_signal_dispatch')) {
+                pcntl_signal_dispatch();
+            }
             if ( $this->shouldStop ) break;
 
             try {


### PR DESCRIPTION
That at this time compatible with PHP 5.3 and graceful degradation for running on Windows