### PR TITLE
DoctrineWriter: fix setting associations

### DIFF
--- a/src/Ddeboer/DataImport/Reader/CsvReader.php
+++ b/src/Ddeboer/DataImport/Reader/CsvReader.php
@@ -9,7 +9,7 @@ use Ddeboer\DataImport\Exception\DuplicateHeadersException;
  *
  * @author David de Boer <david@ddeboer.nl>
  */
-class CsvReader implements CountableReaderInterface, \SeekableIterator
+class CsvReader implements CountableReaderInterface, ErrorProneReaderInterface, \SeekableIterator
 {
     const DUPLICATE_HEADERS_INCREMENT = 1;
     const DUPLICATE_HEADERS_MERGE     = 2;

--- a/src/Ddeboer/DataImport/Reader/ErrorProneReaderInterface.php
+++ b/src/Ddeboer/DataImport/Reader/ErrorProneReaderInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Ddeboer\DataImport\Reader;
+
+/**
+ * Reader that provides feedback for read errors
+ *
+ * @author buddhaCode <buddhaCode@users.noreply.github.com>
+ */
+interface ErrorProneReaderInterface extends ReaderInterface
+{
+    /**
+     * Get rows that have an invalid number of columns
+     *
+     * @return array
+     */
+    public function getErrors();
+
+    /**
+     * Does the reader contain any invalid rows?
+     *
+     * @return bool
+     */
+    public function hasErrors();
+
+}

--- a/src/Ddeboer/DataImport/Workflow.php
+++ b/src/Ddeboer/DataImport/Workflow.php
@@ -272,6 +272,21 @@ class Workflow
             $count++;
         }
 
+        // Collect reader errors
+        if ($this->reader instanceof Reader\ErrorProneReaderInterface && $this->reader->hasErrors()) {
+            foreach ($this->reader->getErrors() as $readerLine => $readerError) {
+                // Shift existing exceptions and increase their line numbers
+                foreach ($exceptions as $exceptionLine => $exception) {
+                    $shiftedExceptions[$exceptionLine+1] = $exception;
+                }
+                // Insert reader error and convert to ReaderException
+                $shiftedExceptions[$readerLine] = new Exception\ReaderException('Number of fields mismatches the number of headers: ' . implode(';', $readerError));
+                // Add malicious line to number of total lines processed
+                $count++;
+                $exceptions = $shiftedExceptions;
+            }
+        }
+        
         // Finish writers
         foreach ($this->writers as $writer) {
             $writer->finish();

--- a/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
+++ b/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
@@ -210,8 +210,7 @@ class DoctrineWriter extends AbstractWriter
      */
     protected function updateEntity(array $item, $entity)
     {
-        $fieldNames = array_merge($this->entityMetadata->getFieldNames(), $this->entityMetadata->getAssociationNames());
-        foreach ($fieldNames as $fieldName) {
+        foreach ($$this->entityMetadata->getFieldNames() as $fieldName) {
 
             $value = null;
             if (isset($item[$fieldName])) {


### PR DESCRIPTION
The associations set in loadAssociationObjectsToEntity() method will be overwritten by the original value/foreign key. This will lead to an Doctrine exception, coz Doctrine is expecting an entity object and not a scalar value.