### PR TITLE
Atomic writes

### DIFF
--- a/src/Ddeboer/DataImport/Workflow.php
+++ b/src/Ddeboer/DataImport/Workflow.php
@@ -285,11 +285,13 @@ class Workflow
             $count++;
         }
 
-        // Finish writers
-        foreach ($this->writers as $writer) {
-            $writer->finish();
+        if ( !($this->atomicWrites AND $filterFail)) {
+	        // Finish writers
+	        foreach ($this->writers as $writer) {
+	            $writer->finish();
+	        }
         }
-
+        
         return new Result($this->name, $startTime, new DateTime, $count, $exceptions);
     }
 

--- a/src/Ddeboer/DataImport/Workflow.php
+++ b/src/Ddeboer/DataImport/Workflow.php
@@ -234,6 +234,7 @@ class Workflow
      * Checks to see if we are using atomicWrites, and if so we need to increment the processedCount
      * and return true
      * 
+     * @param  boolean the current value
      * @return boolean
      */
     protected function incrementProcessedCountIfAtomic($filterFail)

--- a/tests/Ddeboer/DataImport/Tests/WorkflowTest.php
+++ b/tests/Ddeboer/DataImport/Tests/WorkflowTest.php
@@ -382,6 +382,34 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(null, $result->getName());
     }
 
+    public function testAtomicWrites()
+    {
+        $workflow   = $this->getWorkflow();
+        $workflow->setAtomicWrites(true);
+        $writer     = $this->getMock('Ddeboer\DataImport\Writer\WriterInterface');
+        
+        // So THIS HERE needs to only return false on the FIRST call
+        $validatorFilter = $this->getMockBuilder('\Ddeboer\DataImport\Filter\ValidatorFilter')
+            ->disableOriginalConstructor()
+            ->setMethods(array('filter'))
+            ->getMock();
+                
+        $validatorFilter->method('filter')
+            ->will($this->returnValue(false));
+        
+        $result = $workflow
+            ->addFilter($validatorFilter)
+            ->addWriter($writer)
+            ->process();
+        
+        $this->assertSame(0, $result->getTotalProcessedCount());
+        $this->assertSame(0, $result->getSuccessCount());
+        $this->assertSame(0, $result->getErrorCount());
+//        $this->assertTrue($result->hasErrors());
+        
+    }
+    
+    
     protected function getWorkflow()
     {
         $reader = new ArrayReader(array(

--- a/tests/Ddeboer/DataImport/Tests/WorkflowTest.php
+++ b/tests/Ddeboer/DataImport/Tests/WorkflowTest.php
@@ -388,25 +388,31 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $workflow->setAtomicWrites(true);
         $writer     = $this->getMock('Ddeboer\DataImport\Writer\WriterInterface');
         
-        // So THIS HERE needs to only return false on the FIRST call
         $validatorFilter = $this->getMockBuilder('\Ddeboer\DataImport\Filter\ValidatorFilter')
             ->disableOriginalConstructor()
             ->setMethods(array('filter'))
             ->getMock();
                 
-        $validatorFilter->method('filter')
+        // Validate at least 1 false and 1 true
+        $validatorFilter
+            ->expects($this->at(0))
+            ->method('filter')
             ->will($this->returnValue(false));
+        
+        $validatorFilter
+            ->expects($this->at(1))
+            ->method('filter')
+            ->will($this->returnValue(true));
         
         $result = $workflow
             ->addFilter($validatorFilter)
             ->addWriter($writer)
             ->process();
         
-        $this->assertSame(0, $result->getTotalProcessedCount());
+        $this->assertSame(3, $result->getTotalProcessedCount());
         $this->assertSame(0, $result->getSuccessCount());
-        $this->assertSame(0, $result->getErrorCount());
-//        $this->assertTrue($result->hasErrors());
-        
+        $this->assertSame(3, $result->getErrorCount());
+        $this->assertTrue($result->hasErrors());
     }
     
     


### PR DESCRIPTION
I've added the ability to set atomic writes to true for the workflow - if set to true true then no writes will happen if any of the rows from the reader are filtered due to any of the filters.

Because this changes the nature of the processed / success / error counts, I have had to make some changes here.  If atomicWrites is true, and a row fails validation, then for the workflow:
* The processed count will be the total number of rows read
* Every row will have a ReaderException added ('Row skipped due to atomic writes') - they will still be read so that all errors can be reported
* The success count will be 0

I haven't added any documentation for this, but can do so.