### PR TITLE
DoctrineWriter: fix setting associations

### DIFF
--- a/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
+++ b/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
@@ -210,7 +210,7 @@ class DoctrineWriter extends AbstractWriter
      */
     protected function updateEntity(array $item, $entity)
     {
-        foreach ($$this->entityMetadata->getFieldNames() as $fieldName) {
+        foreach ($this->entityMetadata->getFieldNames() as $fieldName) {
 
             $value = null;
             if (isset($item[$fieldName])) {

--- a/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
+++ b/src/Ddeboer/DataImport/Writer/DoctrineWriter.php
@@ -210,8 +210,7 @@ class DoctrineWriter extends AbstractWriter
      */
     protected function updateEntity(array $item, $entity)
     {
-        $fieldNames = array_merge($this->entityMetadata->getFieldNames(), $this->entityMetadata->getAssociationNames());
-        foreach ($fieldNames as $fieldName) {
+        foreach ($$this->entityMetadata->getFieldNames() as $fieldName) {
 
             $value = null;
             if (isset($item[$fieldName])) {


### PR DESCRIPTION
The associations set in loadAssociationObjectsToEntity() method will be overwritten by the original value/foreign key. This will lead to an Doctrine exception, coz Doctrine is expecting an entity object and not a scalar value.
