### PR TITLE
add setter for parameters

### DIFF
--- a/src/Reader/PdoReader.php
+++ b/src/Reader/PdoReader.php
@@ -39,6 +39,17 @@ class PdoReader implements CountableReader
         $this->pdo = $pdo;
         $this->statement = $this->pdo->prepare($sql);
 
+        $this->setParameters($params);
+    }
+
+    /**
+     * Parameter setter. Useful if you build the reader with DI but need to
+     * inject dynamic parameters.
+     *
+     * @param array $params SQL statement parameters
+     */
+    public function setParameters(array $params)
+    {
         foreach ($params as $key => $value) {
             $this->statement->bindValue($key, $value);
         }


### PR DESCRIPTION
When using DI to build the PdoReader, it is not always to know what the
parameters will be at construction time. For instance, if one parameter
is a CLI parameter. The setter makes adding parameter after construction
possible.