### PR TITLE
add alias to subquery in doCalcRowCount()

### DIFF
--- a/src/Reader/DbalReader.php
+++ b/src/Reader/DbalReader.php
@@ -199,7 +199,7 @@ class DbalReader implements CountableReader
 
     private function doCalcRowCount()
     {
-        $statement = $this->prepare(sprintf('SELECT COUNT(*) FROM (%s)', $this->sql), $this->params);
+        $statement = $this->prepare(sprintf('SELECT COUNT(*) FROM (%s) AS qry', $this->sql), $this->params);
         $statement->execute();
 
         $this->rowCount = (int) $statement->fetchColumn(0);


### PR DESCRIPTION
Without such alias, I get this error: "SQLSTATE[42000]: Syntax error or access violation: 1248 Every derived table must have its own alias"