### PR TITLE
Allow DoctrineWriter to use an repository method for retrieval

### DIFF
--- a/src/Writer/DoctrineWriter.php
+++ b/src/Writer/DoctrineWriter.php
@@ -34,6 +34,11 @@ class DoctrineWriter implements Writer, FlushableWriter
     protected $entityRepository;
 
     /**
+     * @var string
+     */
+    protected $entityRepositoryMethod;
+
+    /**
      * @var ClassMetadata
      */
     protected $entityMetadata;
@@ -280,9 +285,14 @@ class DoctrineWriter implements Writer, FlushableWriter
                 foreach ($this->lookupFields as $fieldName) {
                     $lookupConditions[$fieldName] = $item[$fieldName];
                 }
-                $entity = $this->entityRepository->findOneBy(
-                    $lookupConditions
-                );
+
+                if ($this->entityRepositoryMethod && method_exists($this->entityRepository, $this->entityRepositoryMethod)) {
+                    $entity = call_user_func([$this->entityRepository, $this->entityRepositoryMethod], $lookupConditions);
+                } else {
+                    $entity = $this->entityRepository->findOneBy(
+                        $lookupConditions
+                    );
+                }
             } else {
                 $entity = $this->entityRepository->find(current($item));
             }
@@ -302,5 +312,15 @@ class DoctrineWriter implements Writer, FlushableWriter
     {
         $this->entityManager->flush();
         $this->entityManager->clear($this->entityName);
+    }
+
+    /**
+     * @param string $entityRepositoryMethod
+     * @return DoctrineWriter
+     */
+    public function setEntityRepositoryMethod($entityRepositoryMethod)
+    {
+        $this->entityRepositoryMethod = $entityRepositoryMethod;
+        return $this;
     }
 }

--- a/src/Writer/DoctrineWriter.php
+++ b/src/Writer/DoctrineWriter.php
@@ -321,7 +321,7 @@ class DoctrineWriter implements Writer, FlushableWriter
     public function setEntityRepositoryMethod($entityRepositoryMethod)
     {
         if (!method_exists($this->entityRepository, $entityRepositoryMethod)) {
-            throw new \InvalidArgumentException(sprintf('Repository method %s does not exist in reposistory %s',$entityRepositoryMethod,$this->entityRepository));
+            throw new \InvalidArgumentException(sprintf('Repository method %s does not exist in reposistory %s',$entityRepositoryMethod,get_class($this->entityRepository)));
         }
 
         $this->entityRepositoryMethod = [$this->entityRepository,$entityRepositoryMethod];

--- a/src/Writer/DoctrineWriter.php
+++ b/src/Writer/DoctrineWriter.php
@@ -286,8 +286,8 @@ class DoctrineWriter implements Writer, FlushableWriter
                     $lookupConditions[$fieldName] = $item[$fieldName];
                 }
 
-                if ($this->entityRepositoryMethod && method_exists($this->entityRepository, $this->entityRepositoryMethod)) {
-                    $entity = call_user_func([$this->entityRepository, $this->entityRepositoryMethod], $lookupConditions);
+                if ($this->entityRepositoryMethod) {
+                    $entity = call_user_func($this->entityRepositoryMethod, $lookupConditions);
                 } else {
                     $entity = $this->entityRepository->findOneBy(
                         $lookupConditions
@@ -320,7 +320,11 @@ class DoctrineWriter implements Writer, FlushableWriter
      */
     public function setEntityRepositoryMethod($entityRepositoryMethod)
     {
-        $this->entityRepositoryMethod = $entityRepositoryMethod;
+        if (!method_exists($this->entityRepository, $entityRepositoryMethod)) {
+            throw new \InvalidArgumentException(sprintf('Repository method %s does not exist in reposistory %s',$entityRepositoryMethod,$this->entityRepository));
+        }
+
+        $this->entityRepositoryMethod = [$this->entityRepository,$entityRepositoryMethod];
         return $this;
     }
 }


### PR DESCRIPTION
Using a repository method allows for joins and other potential security
wrappers to do their thing.
