### PR TITLE
Change CSV Writer's default delimiter

### DIFF
--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -36,7 +36,7 @@ class CsvWriter extends AbstractStreamWriter
      * @param resource $stream
      * @param boolean  $utf8Encoding
      */
-    public function __construct($delimiter = ';', $enclosure = '"', $stream = null, $utf8Encoding = false, $prependHeaderRow = false)
+    public function __construct($delimiter = ',', $enclosure = '"', $stream = null, $utf8Encoding = false, $prependHeaderRow = false)
     {
         parent::__construct($stream);
 


### PR DESCRIPTION
By convention CSV files are delimited by commas. This changes the
CsvWriter to use a comma by default.