### PR TITLE
Fix addStep clobering numerical priorities

### DIFF
--- a/src/Workflow/StepAggregator.php
+++ b/src/Workflow/StepAggregator.php
@@ -80,7 +80,7 @@ class StepAggregator implements Workflow, LoggerAwareInterface
      */
     public function addStep(Step $step, $priority = null)
     {
-        $priority = null === $priority && $step instanceof PriorityStep ? $step->getPriority() : null;
+        $priority = null === $priority && $step instanceof PriorityStep ? $step->getPriority() : $priority;
         $priority = null === $priority ? 0 : $priority;
 
         $this->steps->insert($step, $priority);


### PR DESCRIPTION
If you pass in a priority to addStep it will get set to null if
the step doesn't implement PriorityStep.