### PR TITLE
PDO Writer fails if table name is reserved word.

### DIFF
--- a/src/Writer/PdoWriter.php
+++ b/src/Writer/PdoWriter.php
@@ -68,7 +68,7 @@ class PdoWriter implements Writer, FlushableWriter
         if (null === $this->statement) {
             try {
                 $this->statement = $this->pdo->prepare(sprintf(
-                    'INSERT INTO %s (%s) VALUES (%s)',
+                    'INSERT INTO `%s` (%s) VALUES (%s)',
                     $this->tableName,
                     implode(',', array_keys($item)),
                     substr(str_repeat('?,', count($item)), 0, -1)

--- a/tests/Writer/PdoWriterTest.php
+++ b/tests/Writer/PdoWriterTest.php
@@ -3,7 +3,6 @@
 namespace Ddeboer\DataImport\Tests\Writer;
 
 use Ddeboer\DataImport\Writer\PdoWriter;
-use PhpSpec\Exception\Exception;
 
 class PdoWriterTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Writer/PdoWriterTest.php
+++ b/tests/Writer/PdoWriterTest.php
@@ -3,6 +3,7 @@
 namespace Ddeboer\DataImport\Tests\Writer;
 
 use Ddeboer\DataImport\Writer\PdoWriter;
+use PhpSpec\Exception\Exception;
 
 class PdoWriterTest extends \PHPUnit_Framework_TestCase
 {
@@ -46,6 +47,27 @@ class PdoWriterTest extends \PHPUnit_Framework_TestCase
         $stmnt = $this->pdo->query('SELECT * FROM `example`');
         $this->assertEquals(
             array(array('a'=>'foo', 'b'=>'bar'), array('a'=>'cat', 'b'=>'dog'), array('a'=>'ac', 'b'=>'dc')),
+            $stmnt->fetchAll(\PDO::FETCH_ASSOC),
+            'database does not contain all expected rows'
+        );
+    }
+
+    /**
+     *
+     */
+    public function testValidWriteToReservedNameTable()
+    {
+        $this->pdo->exec('DROP TABLE IF EXISTS `TABLE`');
+        $this->pdo->exec('CREATE TABLE `TABLE` (a TEXT, b TEXT)');
+
+        $writer = new PdoWriter($this->pdo, 'TABLE');
+        $writer->prepare();
+        $writer->writeItem(array('a' => 'foo', 'b' => 'bar'));
+        $writer->finish();
+
+        $stmnt = $this->pdo->query('SELECT * FROM `TABLE`');
+        $this->assertEquals(
+            array(array('a'=>'foo', 'b'=>'bar')),
             $stmnt->fetchAll(\PDO::FETCH_ASSOC),
             'database does not contain all expected rows'
         );


### PR DESCRIPTION
added back ticks around the table name to the INSERT statement in the PDO writer