### PR TITLE
Optionally clear entity manager

### DIFF
--- a/src/Writer/DoctrineWriter.php
+++ b/src/Writer/DoctrineWriter.php
@@ -60,6 +60,13 @@ class DoctrineWriter implements Writer, FlushableWriter
     protected $lookupFields = array();
 
     /**
+     * Whether to clear the entity manager
+     *
+     * @var boolean
+     */
+    protected $clearOnFlush = true;
+
+    /**
      * @param EntityManagerInterface $entityManager
      * @param string                 $entityName
      * @param string|array           $index Field or fields to find current entities by
@@ -301,6 +308,17 @@ class DoctrineWriter implements Writer, FlushableWriter
     public function flush()
     {
         $this->entityManager->flush();
-        $this->entityManager->clear($this->entityName);
+
+        if($this->clearOnFlush) {
+            $this->entityManager->clear($this->entityName);
+        }
+    }
+
+    /**
+     * @param boolean $clearOnFlush
+     */
+    public function setClearOnFlush($clearOnFlush)
+    {
+        $this->clearOnFlush = $clearOnFlush;
     }
 }


### PR DESCRIPTION
Some bugs occur due to flushing the entity manager. This provides
a user the option to clear or not.

This seems to be left over from the old library where it had built
in batch handling. As if a developer/user would batch process in the
same memory process. This is likely not to be the case I would think.
So could be reviewed for removal. I know I've hit 3 different bugs/issues
because of calling clear().
