### PR TITLE
Improve Result interface

### DIFF
--- a/src/Exception/StopException.php
+++ b/src/Exception/StopException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Ddeboer\DataImport\Exception;
+
+use Ddeboer\DataImport\Exception;
+
+class StopException extends \RuntimeException implements Exception
+{
+
+}

--- a/src/Filter/OffsetFilter.php
+++ b/src/Filter/OffsetFilter.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Ddeboer\DataImport\Filter;
+use Ddeboer\DataImport\Exception\StopException;
 
 /**
  * This filter can be used to filter out some items from the beginning and/or
@@ -36,13 +37,19 @@ class OffsetFilter
     protected $maxLimitHit = false;
 
     /**
+     * @var boolean
+     */
+    protected $stopOnMaxLimit = false;
+
+    /**
      * @param integer      $offset 0-based index of the item to start read from
      * @param integer|null $limit  Maximum count of items to read. null = no limit
      */
-    public function __construct($offset = 0, $limit = null)
+    public function __construct($offset = 0, $limit = null, $stopOnLimit = false)
     {
         $this->offset = $offset;
         $this->limit = $limit;
+        $this->stopOnMaxLimit = ($limit>0 && $stopOnLimit);
     }
 
     /**
@@ -52,6 +59,10 @@ class OffsetFilter
     {
         // In case we've already filtered up to limited
         if ($this->maxLimitHit) {
+            if($this->stopOnMaxLimit) {
+                throw new StopException();
+            }
+
             return false;
         }
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -57,18 +57,25 @@ class Result
      * @param string            $name
      * @param \DateTime         $startTime
      * @param \DateTime         $endTime
-     * @param integer           $totalCount
+     * @param integer           $processed
+     * @param integer           $imported
+     * @param integer           $skipped
+     * @param integer           $errors
      * @param \SplObjectStorage $exceptions
      */
-    public function __construct($name, \DateTime $startTime, \DateTime $endTime, $totalCount, \SplObjectStorage $exceptions)
+    public function __construct($name, \DateTime $startTime, \DateTime $endTime, $processed, $imported, $skipped, $errors, \SplObjectStorage $exceptions)
     {
         $this->name                = $name;
         $this->startTime           = $startTime;
         $this->endTime             = $endTime;
         $this->elapsed             = $startTime->diff($endTime);
-        $this->totalProcessedCount = $totalCount;
-        $this->errorCount          = count($exceptions);
-        $this->successCount        = $totalCount - $this->errorCount;
+
+        //Should expect $processed = $errors+$imported+$skipped
+        $this->totalProcessedCount = $processed;
+        $this->errorCount          = $errors;
+        $this->successCount        = $imported;
+        $this->skippedCount        = $skipped;
+
         $this->exceptions          = $exceptions;
     }
 

--- a/src/Workflow/StepAggregator.php
+++ b/src/Workflow/StepAggregator.php
@@ -107,7 +107,11 @@ class StepAggregator implements Workflow, LoggerAwareInterface
      */
     public function process()
     {
-        $count      = 0;
+        $processed  = 0;
+        $skipped    = 0;
+        $errors     = 0;
+        $imported   = 0;
+
         $exceptions = new \SplObjectStorage();
         $startTime  = new \DateTime;
 
@@ -131,9 +135,12 @@ class StepAggregator implements Workflow, LoggerAwareInterface
                 break;
             }
 
+            $processed++;
+
             try {
                 foreach (clone $this->steps as $step) {
                     if (false === $step->process($item)) {
+                        $skipped++;
                         continue 2;
                     }
                 }
@@ -145,23 +152,26 @@ class StepAggregator implements Workflow, LoggerAwareInterface
                 foreach ($this->writers as $writer) {
                     $writer->writeItem($item);
                 }
+            } catch(Exception\StopException $e) {
+                break;
             } catch(Exception $e) {
                 if (!$this->skipItemOnFailure) {
                     throw $e;
                 }
 
+                $errors++;
                 $exceptions->attach($e, $index);
                 $this->logger->error($e->getMessage());
             }
 
-            $count++;
+            $imported++;
         }
 
         foreach ($this->writers as $writer) {
             $writer->finish();
         }
 
-        return new Result($this->name, $startTime, new \DateTime, $count, $exceptions);
+        return new Result($this->name, $startTime, new \DateTime, $processed, $imported, $skipped, $errors, $exceptions);
     }
 
     /**

--- a/tests/Filter/OffsetFilterTest.php
+++ b/tests/Filter/OffsetFilterTest.php
@@ -48,4 +48,22 @@ class OffsetFilterTest extends \PHPUnit_Framework_TestCase
         $resultItems = $this->applyFilter(new OffsetFilter(1, 1), $items);
         $this->assertEquals($resultItems, array('second'));
     }
+
+    /**
+     * @expectedException \Ddeboer\DataImport\Exception\StopException
+     */
+    public function testMaxCountStop()
+    {
+        $items = array('first','second','third','fourth');
+        $this->applyFilter(new OffsetFilter(0, 2, true), $items);
+    }
+
+    /**
+     * @expectedException \Ddeboer\DataImport\Exception\StopException
+     */
+    public function testOffsetWithMaxCountStop()
+    {
+        $items = array('first','second','third','fourth');
+        $this->applyFilter(new OffsetFilter(1, 1, true), $items);
+    }
 }

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -13,13 +13,13 @@ class ResultTest extends \PHPUnit_Framework_TestCase
 {
     public function testResultName()
     {
-        $result = new Result('export', new \DateTime, new \DateTime, 10, new \SplObjectStorage());
+        $result = new Result('export', new \DateTime, new \DateTime, 10, 10, 0, 0, new \SplObjectStorage());
         $this->assertSame('export', $result->getName());
     }
 
     public function testResultCounts()
     {
-        $result = new Result('export', new \DateTime, new \DateTime, 10, new \SplObjectStorage());
+        $result = new Result('export', new \DateTime, new \DateTime, 10, 10, 0, 0, new \SplObjectStorage());
         $this->assertSame(10, $result->getTotalProcessedCount());
         $this->assertSame(10, $result->getSuccessCount());
         $this->assertSame(0, $result->getErrorCount());
@@ -27,7 +27,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
         $exceptions = new \SplObjectStorage();
         $exceptions->attach(new \Exception());
         $exceptions->attach(new \Exception());
-        $result = new Result('export', new \DateTime, new \DateTime, 10, $exceptions);
+        $result = new Result('export', new \DateTime, new \DateTime, 10, 8, 0, 2, $exceptions);
         $this->assertSame(10, $result->getTotalProcessedCount());
         $this->assertSame(8, $result->getSuccessCount());
         $this->assertSame(2, $result->getErrorCount());
@@ -39,7 +39,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
         $startDate  = new \DateTime("22-07-2014 22:00");
         $endDate    = new \DateTime("22-07-2014 23:30");
 
-        $result     = new Result('export', $startDate, $endDate, 10, new \SplObjectStorage());
+        $result     = new Result('export', $startDate, $endDate, 10, 10, 0, 0, new \SplObjectStorage());
 
         $this->assertSame($startDate, $result->getStartTime());
         $this->assertSame($endDate, $result->getEndTime());
@@ -52,13 +52,13 @@ class ResultTest extends \PHPUnit_Framework_TestCase
         $exceptions->attach(new \Exception());
         $exceptions->attach(new \Exception());
 
-        $result = new Result('export', new \DateTime, new \DateTime, 10, $exceptions);
+        $result = new Result('export', new \DateTime, new \DateTime, 10, 10, 0, 2, $exceptions);
         $this->assertTrue($result->hasErrors());
     }
 
     public function testHasErrorsReturnsFalseIfNoExceptions()
     {
-        $result = new Result('export', new \DateTime, new \DateTime, 10, new \SplObjectStorage());
+        $result = new Result('export', new \DateTime, new \DateTime, 10, 10, 0, 0, new \SplObjectStorage());
         $this->assertFalse($result->hasErrors());
     }
 
@@ -68,7 +68,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
         $exceptions->attach(new \Exception());
         $exceptions->attach(new \Exception());
 
-        $result = new Result('export', new \DateTime, new \DateTime, 10, $exceptions);
+        $result = new Result('export', new \DateTime, new \DateTime, 10, 10, 0, 2, $exceptions);
         $this->assertSame($exceptions, $result->getExceptions());
     }
 }


### PR DESCRIPTION
Allow the Offset filter to stop the process function loop. The impetus is the
lack of detail the result object contains - particularly when using the Offset
filter. When processing a file in chunks the StepAggregator reports the number
of successfully imported results and errors but not the number of skipped. This
allows a user to seek the reader, and then process a batch and then stop.
Receiving an accurate set of processed,skipped and errors.