### PR TITLE
Updated link to PHPExcel library

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ $reader = new DoctrineReader($entityManager, 'Your\Namespace\Entity\User');
 
 #### ExcelReader
 
-Acts as an adapter for the [PHPExcel library](http://phpexcel.codeplex.com/). Make sure
+Acts as an adapter for the [PHPExcel library](https://github.com/PHPOffice/PHPExcel). Make sure
 to include that library in your project:
 
 ```bash


### PR DESCRIPTION
On Codeplex we find this message:

    2015-08-10 Friendly Reminder!
    We moved to https://github.com/PHPOffice/PHPExcel over 3 years ago
    The site here on codeplex is no longer current