### PR TITLE
Batch writer duplicates writes

### DIFF
--- a/src/Writer/BatchWriter.php
+++ b/src/Writer/BatchWriter.php
@@ -50,8 +50,11 @@ class BatchWriter implements Writer
             $this->delegate->writeItem($item);
         }
 
+        $this->queue = new \SplQueue();
+
         if ($this->delegate instanceof FlushableWriter) {
             $this->delegate->flush();
+            $this->delegate->prepare();
         }
     }
 }

--- a/tests/Writer/BatchWriterTest.php
+++ b/tests/Writer/BatchWriterTest.php
@@ -26,12 +26,38 @@ class BatchWriterTest extends \PHPUnit_Framework_TestCase
         $delegate = $this->getMock('Ddeboer\DataImport\Writer');
         $writer = new BatchWriter($delegate);
 
-        $delegate->expects($this->exactly(20))
+        $delegate->expects($this->exactly(40))
             ->method('writeItem');
+
+        $delegate->expects($this->once())
+            ->method('prepare');
 
         $writer->prepare();
 
-        for ($i = 0; $i < 20; $i++) {
+        for ($i = 0; $i < 40; $i++) {
+            $writer->writeItem(['Test']);
+        }
+    }
+
+    public function testFlushWithFlushableDelegate()
+    {
+        $prophet = new \Prophecy\Prophet;
+        $prophecy = $prophet->prophesize();
+
+        $prophecy->willExtend('stdClass');
+        $prophecy->willImplement('Ddeboer\DataImport\Writer');
+        $prophecy->willImplement('Ddeboer\DataImport\Writer\FlushableWriter');
+
+        $prophecy->writeItem(\Prophecy\Argument::any())->shouldBeCalledTimes(40);
+
+        $prophecy->prepare()->shouldBeCalledTimes(2);
+        $prophecy->flush()->shouldBeCalled();
+
+        $writer = new BatchWriter($prophecy->reveal());
+
+        $writer->prepare();
+
+        for ($i = 0; $i < 40; $i++) {
             $writer->writeItem(['Test']);
         }
     }


### PR DESCRIPTION
The batch writer never empties it's queue on flush causing subsequent flushes to duplicate the previous iterations.