### PR TITLE
[DoctrineWriter] Return entity after writeItem() method call

### DIFF
--- a/src/Writer/DoctrineWriter.php
+++ b/src/Writer/DoctrineWriter.php
@@ -170,7 +170,9 @@ class DoctrineWriter implements Writer, FlushableWriter
     }
 
     /**
-     * {@inheritdoc}
+     * @param array $item
+     *
+     * @return object
      */
     public function writeItem(array $item)
     {
@@ -180,6 +182,8 @@ class DoctrineWriter implements Writer, FlushableWriter
         $this->updateEntity($item, $entity);
 
         $this->entityManager->persist($entity);
+
+        return $entity;
     }
 
     /**

--- a/tests/Writer/DoctrineWriterTest.php
+++ b/tests/Writer/DoctrineWriterTest.php
@@ -22,7 +22,9 @@ class DoctrineWriterTest extends \PHPUnit_Framework_TestCase
             'secondProperty'  => 'some other value',
             'firstAssociation'=> $association
         );
-        $writer->writeItem($item);
+        $entity = $writer->writeItem($item);
+
+        $this->assertInstanceOf('Ddeboer\DataImport\Tests\Fixtures\Entity\TestEntity', $entity);
     }
 
     protected function getEntityManager()


### PR DESCRIPTION
#271 

This PR add the return of the entity after calling the `writeItem()` on `DoctrineWriter`.