### PR TITLE
Fix for additional empty worksheet in Excel creation

### DIFF
--- a/src/Writer/ExcelWriter.php
+++ b/src/Writer/ExcelWriter.php
@@ -67,6 +67,10 @@ class ExcelWriter implements Writer
             $this->excel = $reader->load($this->filename);
         } else {
             $this->excel = new PHPExcel();
+            if(null !== $this->sheet && !$this->excel->sheetNameExists($this->sheet))
+            {
+                $this->excel->removeSheetByIndex(0);
+            }
         }
 
         if (null !== $this->sheet) {


### PR DESCRIPTION
When instancing the ExcelWriter class, if the first sheet is given a custom name the class adds an empty 'Worksheet'. This is due to the creation of a default sheet operated by the construct of the PHPExcel class.