### PR TITLE
add getter for array in ArrayWriter

### DIFF
--- a/src/Writer/ArrayWriter.php
+++ b/src/Writer/ArrayWriter.php
@@ -27,6 +27,14 @@ class ArrayWriter implements Writer
     }
 
     /**
+     * @return array
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function prepare()


### PR DESCRIPTION
This helps to work on the array after it was progresses without keeping the reference on the array when the instance was produces (like in the AbstractStreamWriter where you also didn't not to keep a reference to the stream because there is a getter for it).
In my case I want to implement a data export to the user, where he can choose the format. The writer is generated in a factory and at the end the header is generated depending on the Writer Instance and the format. I would like to use the ArrayWriter to produce JSON at the end.