### PR TITLE
Adds alias to derived table

### DIFF
--- a/src/Reader/DbalReader.php
+++ b/src/Reader/DbalReader.php
@@ -199,7 +199,7 @@ class DbalReader implements CountableReader
 
     private function doCalcRowCount()
     {
-        $statement = $this->prepare(sprintf('SELECT COUNT(*) FROM (%s)', $this->sql), $this->params);
+        $statement = $this->prepare(sprintf('SELECT COUNT(*) FROM (%s) AS count', $this->sql), $this->params);
         $statement->execute();
 
         $this->rowCount = (int) $statement->fetchColumn(0);


### PR DESCRIPTION
DbalReader was throwing the error below when implementing the ConsoleProgressWriter or otherwise getting a count of the records.

```
[PDOException]
SQLSTATE[42000]: Syntax error or access violation: 1248 Every derived table must have its own alias
```

Here is one possible fix