### PR TITLE
$tableName into backticks

### DIFF
--- a/src/Writer/PdoWriter.php
+++ b/src/Writer/PdoWriter.php
@@ -68,7 +68,7 @@ class PdoWriter implements Writer, FlushableWriter
         if (null === $this->statement) {
             try {
                 $this->statement = $this->pdo->prepare(sprintf(
-                    'INSERT INTO %s (%s) VALUES (%s)',
+                    'INSERT INTO `%s` (%s) VALUES (%s)',
                     $this->tableName,
                     implode(',', array_keys($item)),
                     substr(str_repeat('?,', count($item)), 0, -1)


### PR DESCRIPTION
In case a table name is a reserved word like "where" (which would be stupid ;)) or there is e.g. a "-" in the table name, say `$tableName` would be `Customer-Names` this throws multiple errors. If you put the table name in backticks, it works.

more: https://stackoverflow.com/questions/1962859/importance-of-backtick-around-table-name-in-mysql-query