### PR TITLE
BUGFIX: the column-name does not fit to the result anymore when using…

### DIFF
--- a/src/Reader/CsvReader.php
+++ b/src/Reader/CsvReader.php
@@ -365,7 +365,7 @@ class CsvReader implements CountableReader, \SeekableIterator
      */
     protected function incrementHeaders(array $headers)
     {
-        $incrementedHeaders = array();
+        $incrementedHeaders = [ ];
 
         // Get all headlines that are duplicate or more
         foreach ( array_count_values ( $headers ) as $header => $count ) {
@@ -375,10 +375,16 @@ class CsvReader implements CountableReader, \SeekableIterator
         }
 
         // Replace the headers with the new header name but keep the position ($key) in the array
-        foreach ( $headers as $key => $headerName ) {
-            if (isset ( $incrementedHeaders [$headerName] )) {
-                $prefix = empty ( $headerName ) ? 'UNKNOWN' : '';
-                $headers [$key] = $prefix . $headerName . $incrementedHeaders [$headerName] ++;
+        foreach ($headers as $key => $headerName) {
+            if (isset ($incrementedHeaders [$headerName])) {
+                $prefix = empty ($headerName) ? 'UNKNOWN' : '';
+                $nr     = $incrementedHeaders [$headerName]++;
+
+                // to stay compatible with old test
+                if ($nr == 0)
+                    $nr = '';
+
+                $headers [$key] = $prefix . $headerName . $nr;
             }
         }
 

--- a/src/Reader/CsvReader.php
+++ b/src/Reader/CsvReader.php
@@ -365,19 +365,24 @@ class CsvReader implements CountableReader, \SeekableIterator
      */
     protected function incrementHeaders(array $headers)
     {
-        $incrementedHeaders = [];
-        foreach (array_count_values($headers) as $header => $count) {
+        $incrementedHeaders = array();
+
+        // Get all headlines that are duplicate or more
+        foreach ( array_count_values ( $headers ) as $header => $count ) {
             if ($count > 1) {
-                $incrementedHeaders[] = $header;
-                for ($i = 1; $i < $count; $i++) {
-                    $incrementedHeaders[] = $header . $i;
-                }
-            } else {
-                $incrementedHeaders[] = $header;
+                $incrementedHeaders [$header] = 0;
             }
         }
 
-        return $incrementedHeaders;
+        // Replace the headers with the new header name but keep the position ($key) in the array
+        foreach ( $headers as $key => $headerName ) {
+            if (isset ( $incrementedHeaders [$headerName] )) {
+                $prefix = empty ( $headerName ) ? 'UNKNOWN' : '';
+                $headers [$key] = $prefix . $headerName . $incrementedHeaders [$headerName] ++;
+            }
+        }
+
+        return $headers;
     }
 
     /**


### PR DESCRIPTION
When using the CSVReader with the option
```
		$this->setHeaderRowNumber ( 0, CsvReader::DUPLICATE_HEADERS_INCREMENT );
```
then the column-name does not fit to the result anymore...

see [issue 287](https://github.com/ddeboer/data-import/issues/287)