### PR TITLE
incorrect mapping behavior by column number.

### DIFF
--- a/src/Ddeboer/DataImport/ItemConverter/MappingItemConverter.php
+++ b/src/Ddeboer/DataImport/ItemConverter/MappingItemConverter.php
@@ -81,7 +81,7 @@ class MappingItemConverter implements ItemConverterInterface
         }
 
         // skip equal fields
-        if ($from == $to) {
+        if ($from === $to) {
             return $item;
         }
 


### PR DESCRIPTION
zero column is skipped because 0 == 'string' is always the true
