### PR TITLE
Since DateInterval does not show microseconds, these modifications we…

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -11,6 +11,7 @@ use Ddeboer\DataImport\Exception\ExceptionInterface;
  */
 class Result
 {
+    const MICRO_FORMAT = 'd-m-Y H:i:s.u';
     /**
      * Identifier given to the import/export
      *
@@ -142,5 +143,19 @@ class Result
     public function getExceptions()
     {
         return $this->exceptions;
+    }
+
+    /**
+     * find the elapsed microseconds for the result. This only finds the microsecond difference, use {@link getElapsed()}
+     *
+     * @return number
+     */
+    public function getMicroElapsed()
+    {
+        $microStart = $this->startTime->format('u');
+        $microEnd = $this->endTime->format('u');
+        $microDiff = abs($microEnd - $microStart);
+
+        return $microDiff;
     }
 }

--- a/src/Workflow/StepAggregator.php
+++ b/src/Workflow/StepAggregator.php
@@ -73,7 +73,7 @@ class StepAggregator implements Workflow, LoggerAwareInterface
     /**
      * Add a step to the current workflow
      *
-     * @param Step         $step
+     * @param Step $step
      * @param integer|null $priority
      *
      * @return $this
@@ -107,9 +107,9 @@ class StepAggregator implements Workflow, LoggerAwareInterface
      */
     public function process()
     {
-        $count      = 0;
+        $count = 0;
         $exceptions = new \SplObjectStorage();
-        $startTime  = new \DateTime;
+        $startTime = new \DateTime(date_format(new \DateTime(), 'd-m-Y H:i:s') . substr((string)microtime(), 1, 8));
 
         foreach ($this->writers as $writer) {
             $writer->prepare();
@@ -145,7 +145,7 @@ class StepAggregator implements Workflow, LoggerAwareInterface
                 foreach ($this->writers as $writer) {
                     $writer->writeItem($item);
                 }
-            } catch(Exception $e) {
+            } catch (Exception $e) {
                 if (!$this->skipItemOnFailure) {
                     throw $e;
                 }
@@ -161,7 +161,7 @@ class StepAggregator implements Workflow, LoggerAwareInterface
             $writer->finish();
         }
 
-        return new Result($this->name, $startTime, new \DateTime, $count, $exceptions);
+        return new Result($this->name, $startTime, new \DateTime(date_format(new \DateTime(), 'd-m-Y H:i:s') . substr((string)microtime(), 1, 8)), $count, $exceptions);
     }
 
     /**

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -46,6 +46,16 @@ class ResultTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('DateInterval', $result->getElapsed());
     }
 
+    public function testMicroElapsed()
+    {
+        $startDate = new \DateTime('2016-07-12 20:51:42.805421');
+        $endDate = new \DateTime('2016-07-12 20:51:42.841276');
+        $microElapsed = abs($endDate->format('u') - $startDate->format('u'));
+
+        $result = new Result('export', $startDate, $endDate, 10, new \SplObjectStorage());
+        $this->assertSame($microElapsed, $result->getMicroElapsed());
+    }
+
     public function testHasErrorsReturnsTrueIfAnyExceptions()
     {
         $exceptions = new \SplObjectStorage();


### PR DESCRIPTION
…re made to find the microseconds elapsed for a given result. This allows us to find the microseconds to be used in conjunction with the DateInterval::format. This only finds the elapsed microseconds and no other difference value.
