### PR TITLE
Adjusting ValidatorStep to compile to Symfony Collection constraints...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "ivbre/data-import",
-    "description": "Import data from, and export data to, a range of file formats and media - fork from ddeboer",
+    "name": "ddeboer/data-import",
+    "description": "Import data from, and export data to, a range of file formats and media",
     "keywords": [ "data", "import", "export", "csv", "excel", "doctrine" ],
     "license": "MIT",
     "authors": [
@@ -31,8 +31,9 @@
         "doctrine/orm": "~2.4",
         "symfony/console": "~2.8|~3.0",
         "symfony/validator": "~2.8|~3.0",
-        "phpspec/phpspec": "~2.1",
-        "henrikbjorn/phpspec-code-coverage" : "~1.0"
+        "phpspec/phpspec": "~3.0",
+        "henrikbjorn/phpspec-code-coverage" : "~3.0",
+        "phpunit/phpunit": "^5.6"
     },
     "suggest": {
         "ext-iconv": "For the CharsetValueConverter",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "ddeboer/data-import",
-    "description": "Import data from, and export data to, a range of file formats and media",
+    "name": "ivbre/data-import",
+    "description": "Import data from, and export data to, a range of file formats and media - fork from ddeboer",
     "keywords": [ "data", "import", "export", "csv", "excel", "doctrine" ],
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,8 @@
         "doctrine/orm": "~2.4",
         "symfony/console": "~2.8|~3.0",
         "symfony/validator": "~2.8|~3.0",
-        "phpspec/phpspec": "~3.0",
-        "henrikbjorn/phpspec-code-coverage" : "~3.0",
-        "phpunit/phpunit": "^5.6"
+        "phpspec/phpspec": "~2.1",
+        "henrikbjorn/phpspec-code-coverage" : "~1.0"
     },
     "suggest": {
         "ext-iconv": "For the CharsetValueConverter",

--- a/src/Step/ValidatorStep.php
+++ b/src/Step/ValidatorStep.php
@@ -37,6 +37,10 @@ class ValidatorStep implements PriorityStep
      */
     private $validator;
 
+    /**
+     * Possible options to set for Constraints\Collection
+     * @var array
+     */
     private $possibleOptions = [ 'groups', 'allowExtraFields', 'allowMissingFields', 'extraFieldsMessage', 'missingFieldsMessage' ];
 
     /**

--- a/src/Step/ValidatorStep.php
+++ b/src/Step/ValidatorStep.php
@@ -37,6 +37,8 @@ class ValidatorStep implements PriorityStep
      */
     private $validator;
 
+    private $possibleOptions = [ 'groups', 'allowExtraFields', 'allowMissingFields', 'extraFieldsMessage', 'missingFieldsMessage' ];
+
     /**
      * @param ValidatorInterface $validator
      */
@@ -79,11 +81,17 @@ class ValidatorStep implements PriorityStep
     }
 
     /**
-     * Use this option to allow extra fields without specific validation constraint set.
+     * Add additional options for the constraints
+     * @param string $option
+     * @param $optionValue
      */
-    public function allowExtraFields()
+    public function addOption($option, $optionValue)
     {
-        $this->constraints['allowExtraFields'] = true;
+        if (!isset($this->possibleOptions[$option])) {
+            return;
+        }
+
+        $this->constraints[$option] = $optionValue;
     }
 
     /**

--- a/src/Step/ValidatorStep.php
+++ b/src/Step/ValidatorStep.php
@@ -54,10 +54,10 @@ class ValidatorStep implements PriorityStep
     public function add($field, Constraint $constraint)
     {
         if (!isset($this->constraints[$field])) {
-            $this->constraints[$field] = [];
+            $this->constraints['fields'][$field] = [];
         }
 
-        $this->constraints[$field][] = $constraint;
+        $this->constraints['fields'][$field][] = $constraint;
 
         return $this;
     }
@@ -76,6 +76,14 @@ class ValidatorStep implements PriorityStep
     public function getViolations()
     {
         return $this->violations;
+    }
+
+    /**
+     * Use this option to allow extra fields without specific validation constraint set.
+     */
+    public function allowExtraFields()
+    {
+        $this->constraints['allowExtraFields'] = true;
     }
 
     /**

--- a/tests/Step/ValidatorStepTest.php
+++ b/tests/Step/ValidatorStepTest.php
@@ -17,7 +17,7 @@ class ValidatorStepTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->validator = $this->createMock(ValidatorInterface::class);
+        $this->validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
         $this->filter = new ValidatorStep($this->validator);
     }
 
@@ -86,6 +86,8 @@ class ValidatorStepTest extends \PHPUnit_Framework_TestCase
 
     private function buildConstraintViolation()
     {
-        return $this->createMock('Symfony\Component\Validator\ConstraintViolation');
+        return $this->getMockBuilder('Symfony\Component\Validator\ConstraintViolation')
+                    ->disableOriginalConstructor()
+                    ->getMock();
     }
 }

--- a/tests/Step/ValidatorStepTest.php
+++ b/tests/Step/ValidatorStepTest.php
@@ -4,15 +4,20 @@ namespace Ddeboer\DataImport\Tests\Step;
 
 use Ddeboer\DataImport\Step\ValidatorStep;
 use Symfony\Component\Validator\Constraints;
-use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class ValidatorStepTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var ValidatorInterface */
+    private $validator;
+
+    /** @var ValidatorStep */
+    private $filter;
+
     protected function setUp()
     {
-        $this->validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
-
+        $this->validator = $this->createMock(ValidatorInterface::class);
         $this->filter = new ValidatorStep($this->validator);
     }
 
@@ -35,7 +40,7 @@ class ValidatorStepTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Ddeboer\DataImport\Exception\ValidationException
+     * @expectedException \Ddeboer\DataImport\Exception\ValidationException
      */
     public function testProcessWithExceptions()
     {
@@ -54,6 +59,26 @@ class ValidatorStepTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->filter->process($data));
     }
 
+    public function testProcessWithAllowedExtraFields()
+    {
+        $this->filter->allowExtraFields();
+
+        $data = ['title' => null, 'telephone' => '0155/555-555'];
+
+        $this->filter->add('title', $constraint = new Constraints\NotNull());
+
+        $list = new ConstraintViolationList();
+        $list->add($this->buildConstraintViolation());
+
+        $this->validator->expects($this->once())
+            ->method('validate')
+            ->willReturn($list);
+
+        $this->assertFalse($this->filter->process($data));
+
+        $this->assertEquals([1 => $list], $this->filter->getViolations());
+    }
+
     public function testPriority()
     {
         $this->assertEquals(128, $this->filter->getPriority());
@@ -61,8 +86,6 @@ class ValidatorStepTest extends \PHPUnit_Framework_TestCase
 
     private function buildConstraintViolation()
     {
-        return $this->getMockBuilder('Symfony\Component\Validator\ConstraintViolation')
-                    ->disableOriginalConstructor()
-                    ->getMock();
+        return $this->createMock('Symfony\Component\Validator\ConstraintViolation');
     }
 }

--- a/tests/Step/ValidatorStepTest.php
+++ b/tests/Step/ValidatorStepTest.php
@@ -17,7 +17,7 @@ class ValidatorStepTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->validator = $this->createMock('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $this->validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
         $this->filter = new ValidatorStep($this->validator);
     }
 

--- a/tests/Step/ValidatorStepTest.php
+++ b/tests/Step/ValidatorStepTest.php
@@ -61,7 +61,7 @@ class ValidatorStepTest extends \PHPUnit_Framework_TestCase
 
     public function testProcessWithAllowedExtraFields()
     {
-        $this->filter->allowExtraFields();
+        $this->filter->addOption('allowExtraFields', true);
 
         $data = ['title' => null, 'telephone' => '0155/555-555'];
 


### PR DESCRIPTION
Adjusting **ValidatorStep** to compile with **Symfony Collection** constraints and adding method to enable **allowExtraFields** option.
If you take a look at [Constraints\Collection](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Validator/Constraints/Collection.php)  and the [docs](http://symfony.com/doc/current/reference/constraints/Collection.html) you will notice that in constructor **options** array can have: 'groups', 'fields', 'allowExtraFields', 'allowMissingFields', 'extraFieldsMessage' and 'missingFieldsMessage' elements.
That means that all validation constraints for fields needs to go into **fields** element of this array.
That is why I've changed the method **add** from **ValidatorStep** to include **fields** elements in **constraints** property, and also added an option to enable **allowExtraFields** option, which is false by default.
If you have any questions or additional requests please let me know.
