### PR TITLE
Fix ArrayValueConverterMap converter

### DIFF
--- a/src/ValueConverter/ArrayValueConverterMap.php
+++ b/src/ValueConverter/ArrayValueConverterMap.php
@@ -31,11 +31,7 @@ class ArrayValueConverterMap
             throw new \InvalidArgumentException('Input of a ArrayValueConverterMap must be an array');
         }
 
-        foreach ($input as $key => $item) {
-            $input[$key] = $this->convertItem($item);
-        }
-
-        return $input;
+        return $this->convertItem($input);
     }
 
     /**

--- a/tests/ValueConverter/ArrayValueConverterMapTest.php
+++ b/tests/ValueConverter/ArrayValueConverterMapTest.php
@@ -22,14 +22,8 @@ class ArrayValueConverterMapTest extends \PHPUnit_Framework_TestCase
     public function testConvertWithMultipleFields()
     {
         $data = array(
-            array(
-                'foo' => 'test',
-                'bar' => 'test'
-            ),
-            array(
-                'foo' => 'test2',
-                'bar' => 'test2'
-            ),
+            'foo' => 'test',
+            'bar' => 'test'
         );
 
         $addBarConverter = function($input) { return 'bar'.$input; };
@@ -44,10 +38,7 @@ class ArrayValueConverterMapTest extends \PHPUnit_Framework_TestCase
 
         $data = call_user_func($converter, $data);
 
-        $this->assertEquals('bartest', $data[0]['foo']);
-        $this->assertEquals('barbaztest', $data[0]['bar']);
-
-        $this->assertEquals('bartest2', $data[1]['foo']);
-        $this->assertEquals('barbaztest2', $data[1]['bar']);
+        $this->assertEquals('bartest', $data['foo']);
+        $this->assertEquals('barbaztest', $data['bar']);
     }
 }


### PR DESCRIPTION
It must work with row instead of array of rows. Test was incorrect, so I've updated it as well.

Please note that after introducing "Steps" [each step has](https://github.com/ddeboer/data-import/blob/master/src/Workflow/StepAggregator.php#L136) `$item` as a parameter, and `$item` is a row from e.g. Csv file, that's why ArrayValueConverterMap works incorrectly (actually, it does not work and fails with error `Invalid argument supplied for foreach()`

Fixes #240 

@ddeboer @seydu

After you accept this PR I will update documentation, because now it's impossible to work with this library
