### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ To read the specific sheet:
 $reader = new ExcelReader($file, null, 3);
 ```
 
-###OneToManyReader
+### OneToManyReader
 
 Allows for merging of two data sources (using existing readers), for example you have one CSV with orders and another with order items.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
